### PR TITLE
Improved line coverage coloring

### DIFF
--- a/CoverageExt/CodeRendering/CodeCoverage.cs
+++ b/CoverageExt/CodeRendering/CodeCoverage.cs
@@ -318,7 +318,8 @@ namespace NubiloSoft.CoverageExt.CodeRendering
 
             if (textViewLines == null || line.Extent == null) { return; }
 
-            int lineno = 1 + view.TextSnapshot.GetLineNumberFromPosition(line.Extent.Start);
+            int offsetPosition = VsVersion.Vs2022OrLater ? 0 : 1;
+            int lineno = offsetPosition + view.TextSnapshot.GetLineNumberFromPosition(line.Extent.Start);
 
             CoverageState covered = lineno < coverdata.Length ? coverdata[lineno] : CoverageState.Irrelevant;
 

--- a/CoverageExt/VSExt.CoverageExt.csproj
+++ b/CoverageExt/VSExt.CoverageExt.csproj
@@ -339,6 +339,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PkgCmdID.cs" />
     <Compile Include="Settings.cs" />
+    <Compile Include="VsVersion.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources.resx">

--- a/CoverageExt/VsVersion.cs
+++ b/CoverageExt/VsVersion.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace NubiloSoft.CoverageExt
+{
+    public static class VsVersion
+    {
+        static readonly object mLock = new object();
+        static Version mVsVersion;
+
+        public static Version FullVersion
+        {
+            get
+            {
+                lock (mLock)
+                {
+                    if (mVsVersion == null)
+                    {
+                        string path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "msenv.dll");
+
+                        if (File.Exists(path))
+                        {
+                            FileVersionInfo fvi = FileVersionInfo.GetVersionInfo(path);
+
+                            string verName = fvi.ProductVersion;
+
+                            for (int i = 0; i < verName.Length; i++)
+                            {
+                                if (!char.IsDigit(verName, i) && verName[i] != '.')
+                                {
+                                    verName = verName.Substring(0, i);
+                                    break;
+                                }
+                            }
+                            mVsVersion = new Version(verName);
+                        } else
+                            mVsVersion = new Version(0, 0); // Not running inside Visual Studio!
+                    }
+                }
+
+                return mVsVersion;
+            }
+        }
+
+        public static bool Vs2022OrLater
+        {
+            get { return FullVersion >= new Version(17, 0); }
+        }
+    }
+}

--- a/CoverageExt/VsVersion.cs
+++ b/CoverageExt/VsVersion.cs
@@ -17,12 +17,10 @@ namespace NubiloSoft.CoverageExt
                 {
                     if (mVsVersion == null)
                     {
-                        string path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "msenv.dll");
-
-                        if (File.Exists(path))
+                        try
                         {
+                            string path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "msenv.dll");
                             FileVersionInfo fvi = FileVersionInfo.GetVersionInfo(path);
-
                             string verName = fvi.ProductVersion;
 
                             for (int i = 0; i < verName.Length; i++)
@@ -34,8 +32,11 @@ namespace NubiloSoft.CoverageExt
                                 }
                             }
                             mVsVersion = new Version(verName);
-                        } else
+                        }
+                        catch (FileNotFoundException e)
+                        {
                             mVsVersion = new Version(0, 0); // Not running inside Visual Studio!
+                        }
                     }
                 }
 


### PR DESCRIPTION
Line coverage coloring has been improved.
The change makes the colored lines in Visual Studio consistent with what is in the report.

I don't know why the magic 1 occurs in the code. I was wrote example code and tested it. Here are the contents of the report:

> FILE: C:\Users\Michal.Antoniak\source\repos\TestProject\TestProject\TestProject.cpp
> RES: ___ccc_cc__ccc_c_c_c
> PROF: 

Before this change, Visual Studio displayed the result like this:
![before](https://github.com/user-attachments/assets/95214201-7bde-4599-ac13-2f95a66af20e)

After this change:
![after](https://github.com/user-attachments/assets/8892f655-77d2-4fa1-9b19-d68015be6b29)
