### PR TITLE
Refactoring CoverageExecution.cs

### DIFF
--- a/CoverageExt/CoverageExecution.cs
+++ b/CoverageExt/CoverageExecution.cs
@@ -101,7 +101,7 @@ namespace NubiloSoft.CoverageExt
             throw new Exception("Cannot find vstest.console.exe.");
         }
 
-        private string PrepareArgument( string solutionFolder, string platform, string dllFolder, string dllFilename, string workingDirectory, string commandline, string resultFile )
+        private string PrepareArgument( string solutionFolder, string platform, string dllPath, string workingDirectory, string commandline, string resultFile )
         {
             string PathWithQuotes( string path )
             {
@@ -127,14 +127,14 @@ namespace NubiloSoft.CoverageExt
 
                 argumentBuilder.Append(" -- ");
 
-                if (!dllFilename.EndsWith(".exe", StringComparison.InvariantCultureIgnoreCase))
+                if (!dllPath.EndsWith(".exe", StringComparison.InvariantCultureIgnoreCase))
                 {
                     string vsTestExe = CreateVsTestExePath();
                     argumentBuilder.Append(PathWithQuotes(vsTestExe));
                     argumentBuilder.Append(" /Platform:" + platform + " ");
                 }
 
-                argumentBuilder.Append(PathWithQuotes(Path.Combine(dllFolder, dllFilename)));
+                argumentBuilder.Append(PathWithQuotes(dllPath));
                 if (commandline != null && commandline.Length > 0)
                 {
                     argumentBuilder.Append(" ");
@@ -162,13 +162,13 @@ namespace NubiloSoft.CoverageExt
                 argumentBuilder.Append(sourcesFilter);
                 argumentBuilder.Append(" -- ");
 
-                if (!dllFilename.EndsWith(".exe", StringComparison.InvariantCultureIgnoreCase))
+                if (!dllPath.EndsWith(".exe", StringComparison.InvariantCultureIgnoreCase))
                 {
                     string vsTestExe = CreateVsTestExePath();
                     argumentBuilder.Append(PathWithQuotes(vsTestExe));
                     argumentBuilder.Append(" /Platform:" + platform + " ");
                 }
-                argumentBuilder.Append(PathWithQuotes(Path.Combine(dllFolder, dllFilename)));
+                argumentBuilder.Append(PathWithQuotes(dllPath));
             }
             return argumentBuilder.ToString();
         }
@@ -194,7 +194,7 @@ namespace NubiloSoft.CoverageExt
                     throw new NotSupportedException(fielname + " was not found. Expected: " + process.StartInfo.FileName);
                 }
 
-                string argument = PrepareArgument(solutionFolder, platform, dllFolder, dllFilename, workingDirectory, commandline, tempFile);
+                string argument = PrepareArgument(solutionFolder, platform, Path.Combine(dllFolder, dllFilename), workingDirectory, commandline, tempFile);
 
 #if DEBUG
                 this.output.WriteLine("Execute coverage: {0}", argument);

--- a/CoverageExt/CoverageExecution.cs
+++ b/CoverageExt/CoverageExecution.cs
@@ -156,7 +156,6 @@ namespace NubiloSoft.CoverageExt
                     string vsTestExe = CreateVsTestExePath();
 
                     argumentBuilder.Append("\" -- ");
-                    // C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe
                     argumentBuilder.Append(@"""" + vsTestExe + @"""");
                     argumentBuilder.Append(" /Platform:" + platform + " \"");
                 }
@@ -205,7 +204,9 @@ namespace NubiloSoft.CoverageExt
                     argumentBuilder.Append("--sources ");
                     argumentBuilder.Append(sourcesFilter);
                     argumentBuilder.Append(" -- ");
-                    argumentBuilder.Append(@"""C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe""");
+
+                    string vsTestExe = CreateVsTestExePath();
+                    argumentBuilder.Append(@"""" + vsTestExe + @"""");
                     argumentBuilder.Append(" /Platform:" + platform + " \"");
                     argumentBuilder.Append(Path.Combine(dllFolder, dllFilename));
                     argumentBuilder.Append("\"");

--- a/CoverageExt/CoverageExecution.cs
+++ b/CoverageExt/CoverageExecution.cs
@@ -95,50 +95,46 @@ namespace NubiloSoft.CoverageExt
 
         private string PrepareArgument( string solutionFolder, string platform, string dllFolder, string dllFilename, string workingDirectory, string commandline, string resultFile )
         {
+            string PathWithQuotes( string path )
+            {
+                return @"""" + path + @"""";
+            }
+
             StringBuilder argumentBuilder = new StringBuilder();
             if (Settings.Instance.UseNativeCoverageSupport)
             {
-                argumentBuilder.Append("-o \"");
-                argumentBuilder.Append(resultFile);
-                argumentBuilder.Append("\" -p \"");
-                argumentBuilder.Append(solutionFolder.TrimEnd('\\', '/'));
+                argumentBuilder.Append("-o ");
+                argumentBuilder.Append(PathWithQuotes(resultFile));
+                argumentBuilder.Append(" -p ");
+                argumentBuilder.Append(PathWithQuotes(solutionFolder.TrimEnd('\\', '/')));
 
                 if (workingDirectory != null && workingDirectory.Length > 0)
                 {
                     // When directory finish by \ : c++ read \" and arguments is badly computed !
                     workingDirectory = workingDirectory.TrimEnd('\\', '/');
 
-                    argumentBuilder.Append("\" -w \"");
-                    argumentBuilder.Append(workingDirectory);
-
-                }
-                else
-                {
-                    argumentBuilder.Append("\"");
+                    argumentBuilder.Append(" -w ");
+                    argumentBuilder.Append(PathWithQuotes(workingDirectory));
                 }
 
                 if (dllFilename.EndsWith(".exe", StringComparison.InvariantCultureIgnoreCase))
                 {
-                    argumentBuilder.Append("\" -- \"");
+                    argumentBuilder.Append(" -- ");
                 }
                 else
                 {
                     string vsTestExe = CreateVsTestExePath();
 
-                    argumentBuilder.Append("\" -- ");
-                    argumentBuilder.Append(@"""" + vsTestExe + @"""");
-                    argumentBuilder.Append(" /Platform:" + platform + " \"");
+                    argumentBuilder.Append(" -- ");
+                    argumentBuilder.Append(PathWithQuotes(vsTestExe));
+                    argumentBuilder.Append(" /Platform:" + platform + " ");
                 }
 
-                argumentBuilder.Append(Path.Combine(dllFolder, dllFilename));
+                argumentBuilder.Append(PathWithQuotes(Path.Combine(dllFolder, dllFilename)));
                 if (commandline != null && commandline.Length > 0)
                 {
-                    argumentBuilder.Append("\" ");
+                    argumentBuilder.Append(" ");
                     argumentBuilder.Append(commandline);
-                }
-                else
-                {
-                    argumentBuilder.Append("\"");
                 }
             }
             else
@@ -157,29 +153,27 @@ namespace NubiloSoft.CoverageExt
 
                 if (dllFilename.EndsWith(".exe", StringComparison.InvariantCultureIgnoreCase))
                 {
-                    argumentBuilder.Append("--quiet --export_type cobertura:\"");
-                    argumentBuilder.Append(resultFile);
-                    argumentBuilder.Append("\" --continue_after_cpp_exception --cover_children ");
+                    argumentBuilder.Append("--quiet --export_type cobertura:");
+                    argumentBuilder.Append(PathWithQuotes(resultFile));
+                    argumentBuilder.Append(" --continue_after_cpp_exception --cover_children ");
                     argumentBuilder.Append("--sources ");
                     argumentBuilder.Append(sourcesFilter);
-                    argumentBuilder.Append(" -- \"");
-                    argumentBuilder.Append(Path.Combine(dllFolder, dllFilename));
-                    argumentBuilder.Append("\"");
+                    argumentBuilder.Append(" -- ");
+                    argumentBuilder.Append(PathWithQuotes(Path.Combine(dllFolder, dllFilename)));
                 }
                 else
                 {
-                    argumentBuilder.Append("--quiet --export_type cobertura:\"");
-                    argumentBuilder.Append(resultFile);
-                    argumentBuilder.Append("\" --continue_after_cpp_exception --cover_children ");
+                    argumentBuilder.Append("--quiet --export_type cobertura:");
+                    argumentBuilder.Append(PathWithQuotes(resultFile));
+                    argumentBuilder.Append(" --continue_after_cpp_exception --cover_children ");
                     argumentBuilder.Append("--sources ");
                     argumentBuilder.Append(sourcesFilter);
                     argumentBuilder.Append(" -- ");
 
                     string vsTestExe = CreateVsTestExePath();
-                    argumentBuilder.Append(@"""" + vsTestExe + @"""");
-                    argumentBuilder.Append(" /Platform:" + platform + " \"");
-                    argumentBuilder.Append(Path.Combine(dllFolder, dllFilename));
-                    argumentBuilder.Append("\"");
+                    argumentBuilder.Append(PathWithQuotes(vsTestExe));
+                    argumentBuilder.Append(" /Platform:" + platform + " ");
+                    argumentBuilder.Append(PathWithQuotes(Path.Combine(dllFolder, dllFilename)));
                 }
             }
             return argumentBuilder.ToString();

--- a/CoverageExt/CoverageExecution.cs
+++ b/CoverageExt/CoverageExecution.cs
@@ -76,46 +76,16 @@ namespace NubiloSoft.CoverageExt
             // TODO: We can do much better here by using the registry...
             var folders = new[]
             {
-                @"\Microsoft Visual Studio\2022\Professional\Common7\IDE\Extensions\TestPlatform\",
-                @"\Microsoft Visual Studio\2022\Community\Common7\IDE\Extensions\TestPlatform\",
-                @"\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\Extensions\TestPlatform\",
-                @"\Microsoft Visual Studio\2022\BuildTools\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
-                @"\Microsoft Visual Studio\2019\Community\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
-                @"\Microsoft Visual Studio\2019\Professional\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
-                @"\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
-                @"\Microsoft Visual Studio\2019\BuildTools\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
-                @"\Microsoft Visual Studio\2017\Community\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
-                @"\Microsoft Visual Studio\2017\Professional\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
-                @"\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
-                @"\Microsoft Visual Studio\2017\BuildTools\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
-                @"\Microsoft Visual Studio 19.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
-                @"\Microsoft Visual Studio 16.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
-                @"\Microsoft Visual Studio 15.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
-                @"\Microsoft Visual Studio 14.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
-                @"\Microsoft Visual Studio 13.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\"
+                @"Extensions\TestPlatform\vstest.console.exe",
+                @"CommonExtensions\Microsoft\TestWindow\vstest.console.exe"
             };
-            var pf = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86).TrimEnd('\\');
 
             foreach (var fold in folders)
             {
-                string file = pf + fold + "vstest.console.exe";
+                string file = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, fold);
                 if (File.Exists(file))
                 {
-                    this.output.WriteLine("Found vstest console app.");
-                    return file;
-                }
-            }
-
-            pf = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles).TrimEnd('\\');
-            this.output.WriteLine(pf);
-
-            foreach (var fold in folders)
-            {
-                string file = pf + fold + "vstest.console.exe";
-                this.output.WriteLine(file);
-                if (File.Exists(file))
-                {
-                    this.output.WriteLine("Found vstest console app.");
+                    this.output.WriteLine("Found vstest console app: " + file);
                     return file;
                 }
             }

--- a/CoverageExt/CoverageExecution.cs
+++ b/CoverageExt/CoverageExecution.cs
@@ -71,6 +71,58 @@ namespace NubiloSoft.CoverageExt
             }
         }
 
+        private string CreateVsTestExePath()
+        {
+            // TODO: We can do much better here by using the registry...
+            var folders = new[]
+            {
+                @"\Microsoft Visual Studio\2022\Professional\Common7\IDE\Extensions\TestPlatform\",
+                @"\Microsoft Visual Studio\2022\Community\Common7\IDE\Extensions\TestPlatform\",
+                @"\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\Extensions\TestPlatform\",
+                @"\Microsoft Visual Studio\2022\BuildTools\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
+                @"\Microsoft Visual Studio\2019\Community\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
+                @"\Microsoft Visual Studio\2019\Professional\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
+                @"\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
+                @"\Microsoft Visual Studio\2019\BuildTools\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
+                @"\Microsoft Visual Studio\2017\Community\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
+                @"\Microsoft Visual Studio\2017\Professional\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
+                @"\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
+                @"\Microsoft Visual Studio\2017\BuildTools\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
+                @"\Microsoft Visual Studio 19.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
+                @"\Microsoft Visual Studio 16.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
+                @"\Microsoft Visual Studio 15.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
+                @"\Microsoft Visual Studio 14.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
+                @"\Microsoft Visual Studio 13.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\"
+            };
+            var pf = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86).TrimEnd('\\');
+
+            foreach (var fold in folders)
+            {
+                string file = pf + fold + "vstest.console.exe";
+                if (File.Exists(file))
+                {
+                    this.output.WriteLine("Found vstest console app.");
+                    return file;
+                }
+            }
+
+            pf = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles).TrimEnd('\\');
+            this.output.WriteLine(pf);
+
+            foreach (var fold in folders)
+            {
+                string file = pf + fold + "vstest.console.exe";
+                this.output.WriteLine(file);
+                if (File.Exists(file))
+                {
+                    this.output.WriteLine("Found vstest console app.");
+                    return file;
+                }
+            }
+
+            throw new Exception("Cannot find vstest.console.exe.");
+        }
+
         private string PrepareArgument( string solutionFolder, string platform, string dllFolder, string dllFilename, string workingDirectory, string commandline, string resultFile )
         {
             StringBuilder argumentBuilder = new StringBuilder();
@@ -101,70 +153,11 @@ namespace NubiloSoft.CoverageExt
                 }
                 else
                 {
-                    // TODO: We can do much better here by using the registry...
-                    var folders = new[]
-                    {
-                            @"\Microsoft Visual Studio\2022\Professional\Common7\IDE\Extensions\TestPlatform\",
-                            @"\Microsoft Visual Studio\2022\Community\Common7\IDE\Extensions\TestPlatform\",
-                            @"\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\Extensions\TestPlatform\",
-                            @"\Microsoft Visual Studio\2022\BuildTools\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
-                            @"\Microsoft Visual Studio\2019\Community\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
-                            @"\Microsoft Visual Studio\2019\Professional\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
-                            @"\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
-                            @"\Microsoft Visual Studio\2019\BuildTools\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
-                            @"\Microsoft Visual Studio\2017\Community\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
-                            @"\Microsoft Visual Studio\2017\Professional\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
-                            @"\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
-                            @"\Microsoft Visual Studio\2017\BuildTools\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
-                            @"\Microsoft Visual Studio 19.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
-                            @"\Microsoft Visual Studio 16.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
-                            @"\Microsoft Visual Studio 15.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
-                            @"\Microsoft Visual Studio 14.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
-                            @"\Microsoft Visual Studio 13.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\"
-                        };
-                    var pf = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86).TrimEnd('\\');
-
-                    var foundtestConsole = false;
-                    string filename = null;
-                    foreach (var fold in folders)
-                    {
-                        string file = pf + fold + "vstest.console.exe";
-                        if (File.Exists(file))
-                        {
-                            filename = file;
-                            this.output.WriteLine("Found vstest console app.");
-                            foundtestConsole = true;
-                            break;
-                        }
-                    }
-
-                    if (foundtestConsole == false)
-                    {
-                        pf = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles).TrimEnd('\\');
-                        this.output.WriteLine(pf);
-
-                        filename = null;
-                        foreach (var fold in folders)
-                        {
-                            string file = pf + fold + "vstest.console.exe";
-                            this.output.WriteLine(file);
-                            if (File.Exists(file))
-                            {
-                                filename = file;
-                                this.output.WriteLine("Found vstest console app.");
-                                foundtestConsole = true;
-                                break;
-                            }
-                            else
-                            {
-                                this.output.WriteLine("Cannot find vstest.console.exe.");
-                            }
-                        }
-                    }
+                    string vsTestExe = CreateVsTestExePath();
 
                     argumentBuilder.Append("\" -- ");
                     // C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe
-                    argumentBuilder.Append(@"""" + filename + @"""");
+                    argumentBuilder.Append(@"""" + vsTestExe + @"""");
                     argumentBuilder.Append(" /Platform:" + platform + " \"");
                 }
 

--- a/CoverageExt/CoverageExecution.cs
+++ b/CoverageExt/CoverageExecution.cs
@@ -147,30 +147,20 @@ namespace NubiloSoft.CoverageExt
                     }
                 }
 
-                if (dllFilename.EndsWith(".exe", StringComparison.InvariantCultureIgnoreCase))
-                {
-                    argumentBuilder.Append("--quiet --export_type cobertura:");
-                    argumentBuilder.Append(PathWithQuotes(resultFile));
-                    argumentBuilder.Append(" --continue_after_cpp_exception --cover_children ");
-                    argumentBuilder.Append("--sources ");
-                    argumentBuilder.Append(sourcesFilter);
-                    argumentBuilder.Append(" -- ");
-                    argumentBuilder.Append(PathWithQuotes(Path.Combine(dllFolder, dllFilename)));
-                }
-                else
-                {
-                    argumentBuilder.Append("--quiet --export_type cobertura:");
-                    argumentBuilder.Append(PathWithQuotes(resultFile));
-                    argumentBuilder.Append(" --continue_after_cpp_exception --cover_children ");
-                    argumentBuilder.Append("--sources ");
-                    argumentBuilder.Append(sourcesFilter);
-                    argumentBuilder.Append(" -- ");
+                argumentBuilder.Append("--quiet --export_type cobertura:");
+                argumentBuilder.Append(PathWithQuotes(resultFile));
+                argumentBuilder.Append(" --continue_after_cpp_exception --cover_children ");
+                argumentBuilder.Append("--sources ");
+                argumentBuilder.Append(sourcesFilter);
+                argumentBuilder.Append(" -- ");
 
+                if (!dllFilename.EndsWith(".exe", StringComparison.InvariantCultureIgnoreCase))
+                {
                     string vsTestExe = CreateVsTestExePath();
                     argumentBuilder.Append(PathWithQuotes(vsTestExe));
                     argumentBuilder.Append(" /Platform:" + platform + " ");
-                    argumentBuilder.Append(PathWithQuotes(Path.Combine(dllFolder, dllFilename)));
                 }
+                argumentBuilder.Append(PathWithQuotes(Path.Combine(dllFolder, dllFilename)));
             }
             return argumentBuilder.ToString();
         }

--- a/CoverageExt/CoverageExecution.cs
+++ b/CoverageExt/CoverageExecution.cs
@@ -16,7 +16,6 @@ namespace NubiloSoft.CoverageExt
             this.output = output;
         }
 
-        private StringBuilder sb = new StringBuilder();
         private StringBuilder tb = new StringBuilder();
         private DateTime lastEvent = DateTime.UtcNow;
 

--- a/CoverageExt/CoverageExecution.cs
+++ b/CoverageExt/CoverageExecution.cs
@@ -124,22 +124,6 @@ namespace NubiloSoft.CoverageExt
                     argumentBuilder.Append(" -w ");
                     argumentBuilder.Append(PathWithQuotes(workingDirectory));
                 }
-
-                argumentBuilder.Append(" -- ");
-
-                if (!dllPath.EndsWith(".exe", StringComparison.InvariantCultureIgnoreCase))
-                {
-                    string vsTestExe = CreateVsTestExePath();
-                    argumentBuilder.Append(PathWithQuotes(vsTestExe));
-                    argumentBuilder.Append(" /Platform:" + platform + " ");
-                }
-
-                argumentBuilder.Append(PathWithQuotes(dllPath));
-                if (!String.IsNullOrEmpty(commandline))
-                {
-                    argumentBuilder.Append(" ");
-                    argumentBuilder.Append(commandline);
-                }
             }
             else
             {
@@ -160,16 +144,24 @@ namespace NubiloSoft.CoverageExt
                 argumentBuilder.Append(" --continue_after_cpp_exception --cover_children ");
                 argumentBuilder.Append("--sources ");
                 argumentBuilder.Append(sourcesFilter);
-                argumentBuilder.Append(" -- ");
-
-                if (!dllPath.EndsWith(".exe", StringComparison.InvariantCultureIgnoreCase))
-                {
-                    string vsTestExe = CreateVsTestExePath();
-                    argumentBuilder.Append(PathWithQuotes(vsTestExe));
-                    argumentBuilder.Append(" /Platform:" + platform + " ");
-                }
-                argumentBuilder.Append(PathWithQuotes(dllPath));
             }
+
+            argumentBuilder.Append(" -- ");
+
+            if (!dllPath.EndsWith(".exe", StringComparison.InvariantCultureIgnoreCase))
+            {
+                string vsTestExe = CreateVsTestExePath();
+                argumentBuilder.Append(PathWithQuotes(vsTestExe));
+                argumentBuilder.Append(" /Platform:" + platform + " ");
+            }
+
+            argumentBuilder.Append(PathWithQuotes(dllPath));
+            if (!String.IsNullOrEmpty(commandline))
+            {
+                argumentBuilder.Append(" ");
+                argumentBuilder.Append(commandline);
+            }
+
             return argumentBuilder.ToString();
         }
 

--- a/CoverageExt/CoverageExecution.cs
+++ b/CoverageExt/CoverageExecution.cs
@@ -44,6 +44,14 @@ namespace NubiloSoft.CoverageExt
             }
         }
 
+        private (string, string) CoverageFile( string solutionFolder )
+        {
+            string ext = Settings.Instance.UseNativeCoverageSupport ? ".cov" : ".xml";
+            string resPathBase = Path.Combine(solutionFolder, "CodeCoverage" + ext);
+            string tmpPathBase = Path.Combine(solutionFolder, "CodeCoverage.tmp" + ext);
+            return (resPathBase, tmpPathBase);
+        }
+
         private string CoverageExePath( string platform )
         {
             if (Settings.Instance.UseNativeCoverageSupport)
@@ -172,11 +180,10 @@ namespace NubiloSoft.CoverageExt
                 if (Settings.Instance.UseNativeCoverageSupport)
                 {
                     // Delete old coverage file
-                    string resultFile = Path.Combine(solutionFolder, "CodeCoverage.tmp.cov");
-                    string defResultFile = Path.Combine(solutionFolder, "CodeCoverage.cov");
-                    if (File.Exists(resultFile))
+                    (string resultFile, string tempFile) = CoverageFile(solutionFolder);
+                    if (File.Exists(tempFile))
                     {
-                        File.Delete(resultFile);
+                        File.Delete(tempFile);
                     }
 
                     // Create your Process
@@ -188,7 +195,7 @@ namespace NubiloSoft.CoverageExt
                         throw new NotSupportedException("Coverage.exe instance for platform was not found. Expected: " + process.StartInfo.FileName);
                     }
 
-                    string argument = PrepareArgument(solutionFolder, platform, dllFolder, dllFilename, workingDirectory, commandline, resultFile);
+                    string argument = PrepareArgument(solutionFolder, platform, dllFolder, dllFilename, workingDirectory, commandline, tempFile);
 
 #if DEBUG
                     this.output.WriteLine("Execute coverage: {0}", argument);
@@ -234,14 +241,14 @@ namespace NubiloSoft.CoverageExt
                         throw new Exception("Cannot find test source file " + dllFilename);
                     }
 
-                    if (File.Exists(resultFile))
+                    if (File.Exists(tempFile))
                     {
                         // All fine, update file:
-                        if (File.Exists(defResultFile))
+                        if (File.Exists(resultFile))
                         {
-                            File.Delete(defResultFile);
+                            File.Delete(resultFile);
                         }
-                        File.Move(resultFile, defResultFile);
+                        File.Move(tempFile, resultFile);
                     }
                     else
                     {
@@ -251,11 +258,10 @@ namespace NubiloSoft.CoverageExt
                 else
                 {
                     // Delete old coverage file
-                    string resultFile = Path.Combine(solutionFolder, "CodeCoverage.tmp.xml");
-                    string defResultFile = Path.Combine(solutionFolder, "CodeCoverage.xml");
-                    if (File.Exists(resultFile))
+                    (string resultFile, string tempFile) = CoverageFile(solutionFolder);
+                    if (File.Exists(tempFile))
                     {
-                        File.Delete(resultFile);
+                        File.Delete(tempFile);
                     }
 
                     // Create your Process
@@ -267,13 +273,13 @@ namespace NubiloSoft.CoverageExt
                         throw new NotSupportedException("OpenCPPCoverage was not found. Expected: " + process.StartInfo.FileName);
                     }
 
-                    string argument = PrepareArgument(solutionFolder, platform, dllFolder, dllFilename, workingDirectory, commandline, resultFile);
+                    string argument = PrepareArgument(solutionFolder, platform, dllFolder, dllFilename, workingDirectory, commandline, tempFile);
 
 #if DEBUG
                     this.output.WriteLine("Execute coverage: {0}", argument);
 #endif
 
-                    process.StartInfo.WorkingDirectory = Path.GetDirectoryName(resultFile);
+                    process.StartInfo.WorkingDirectory = Path.GetDirectoryName(tempFile);
                     process.StartInfo.Arguments = argument;
                     process.StartInfo.CreateNoWindow = true;
                     process.StartInfo.UseShellExecute = false;
@@ -313,14 +319,14 @@ namespace NubiloSoft.CoverageExt
                         throw new Exception("Cannot find test source file " + dllFilename);
                     }
 
-                    if (File.Exists(resultFile))
+                    if (File.Exists(tempFile))
                     {
                         // All fine, update file:
-                        if (File.Exists(defResultFile))
+                        if (File.Exists(resultFile))
                         {
-                            File.Delete(defResultFile);
+                            File.Delete(resultFile);
                         }
-                        File.Move(resultFile, defResultFile);
+                        File.Move(tempFile, resultFile);
                     }
                     else
                     {

--- a/CoverageExt/CoverageExecution.cs
+++ b/CoverageExt/CoverageExecution.cs
@@ -192,7 +192,8 @@ namespace NubiloSoft.CoverageExt
 
                     if (!File.Exists(process.StartInfo.FileName))
                     {
-                        throw new NotSupportedException("Coverage.exe instance for platform was not found. Expected: " + process.StartInfo.FileName);
+                        string fielname = Path.GetFileName(process.StartInfo.FileName);
+                        throw new NotSupportedException(fielname + " was not found. Expected: " + process.StartInfo.FileName);
                     }
 
                     string argument = PrepareArgument(solutionFolder, platform, dllFolder, dllFilename, workingDirectory, commandline, tempFile);
@@ -270,7 +271,8 @@ namespace NubiloSoft.CoverageExt
 
                     if (!File.Exists(process.StartInfo.FileName))
                     {
-                        throw new NotSupportedException("OpenCPPCoverage was not found. Expected: " + process.StartInfo.FileName);
+                        string fielname = Path.GetFileName(process.StartInfo.FileName);
+                        throw new NotSupportedException(fielname + " was not found. Expected: " + process.StartInfo.FileName);
                     }
 
                     string argument = PrepareArgument(solutionFolder, platform, dllFolder, dllFilename, workingDirectory, commandline, tempFile);

--- a/CoverageExt/CoverageExecution.cs
+++ b/CoverageExt/CoverageExecution.cs
@@ -117,15 +117,11 @@ namespace NubiloSoft.CoverageExt
                     argumentBuilder.Append(PathWithQuotes(workingDirectory));
                 }
 
-                if (dllFilename.EndsWith(".exe", StringComparison.InvariantCultureIgnoreCase))
-                {
-                    argumentBuilder.Append(" -- ");
-                }
-                else
+                argumentBuilder.Append(" -- ");
+
+                if (!dllFilename.EndsWith(".exe", StringComparison.InvariantCultureIgnoreCase))
                 {
                     string vsTestExe = CreateVsTestExePath();
-
-                    argumentBuilder.Append(" -- ");
                     argumentBuilder.Append(PathWithQuotes(vsTestExe));
                     argumentBuilder.Append(" /Platform:" + platform + " ");
                 }

--- a/CoverageExt/CoverageExecution.cs
+++ b/CoverageExt/CoverageExecution.cs
@@ -116,7 +116,7 @@ namespace NubiloSoft.CoverageExt
                 argumentBuilder.Append(" -p ");
                 argumentBuilder.Append(PathWithQuotes(solutionFolder.TrimEnd('\\', '/')));
 
-                if (workingDirectory != null && workingDirectory.Length > 0)
+                if (!String.IsNullOrEmpty(workingDirectory))
                 {
                     // When directory finish by \ : c++ read \" and arguments is badly computed !
                     workingDirectory = workingDirectory.TrimEnd('\\', '/');
@@ -135,7 +135,7 @@ namespace NubiloSoft.CoverageExt
                 }
 
                 argumentBuilder.Append(PathWithQuotes(dllPath));
-                if (commandline != null && commandline.Length > 0)
+                if (!String.IsNullOrEmpty(commandline))
                 {
                     argumentBuilder.Append(" ");
                     argumentBuilder.Append(commandline);


### PR DESCRIPTION
Find vstest.console.exe path also for cobertura coverage.
Avoiding code repetition. 