### PR TITLE
Fix generation Cobertura report.

### DIFF
--- a/Coverage/FileCallbackInfo.h
+++ b/Coverage/FileCallbackInfo.h
@@ -254,11 +254,11 @@ struct FileCallbackInfo
 				{
 					if (ptr->lines[i].HitCount == ptr->lines[i].DebugCount)
 					{
-						ofs << "\t\t\t\t\t\t" << "<line number=\"" << i << "\" hits=\"1\"/>" << std::endl;
+						ofs << "\t\t\t\t\t\t" << "<line number=\"" << i + 1 << "\" hits=\"1\"/>" << std::endl;
 					}
 					else
 					{
-						ofs << "\t\t\t\t\t\t" << "<line number=\"" << i << "\" hits=\"0\"/>" << std::endl;
+						ofs << "\t\t\t\t\t\t" << "<line number=\"" << i + 1 << "\" hits=\"0\"/>" << std::endl;
 					}
 				}
 			}


### PR DESCRIPTION
Generate a report similar to the one generated by OpenCppCoverave.exe. OpenCppCoverage uses on 1-based indexing.

Tested, compare report:

- opencppcoverage.exe --quiet --export_type cobertura:"C:\TestProject\CodeCoverageOpenCppCoverage.tmp.xml" --continue_after_cpp_exception --cover_children --sources C:\TestProject -- "C:\TestProject\x64\Release\TestProject.exe"

with:

- Coverage-x64.exe -o "C:\TestProject\CodeCoverageCppCoverage.tmp.xml" -format cobertura -p "C:\TestProject" -w "C:\TestProject\TestProject" -- "C:\TestProject\x64\Release\TestProject.exe"