### PR TITLE
Cobertura: Improved removal of line coverage inside #pragma.

### DIFF
--- a/CoverageExt/Cobertura/HandlePragmas.cs
+++ b/CoverageExt/Cobertura/HandlePragmas.cs
@@ -31,7 +31,7 @@ namespace NubiloSoft.CoverageExt.Cobertura
                         string t = line.Substring(idx).TrimStart();
                         if (t.StartsWith("EnableCodeCoverage"))
                         {
-                            data.Remove(i + 1);
+                            data.Remove(i);
                             enabled = true;
                         }
                         else if (t.StartsWith("DisableCodeCoverage"))
@@ -43,7 +43,7 @@ namespace NubiloSoft.CoverageExt.Cobertura
                     // Update data accordingly:
                     if (!enabled)
                     {
-                        data.Remove(i + 1);
+                        data.Remove(i);
                     }
                 }
 
@@ -52,7 +52,7 @@ namespace NubiloSoft.CoverageExt.Cobertura
                     var count = data.Count;
                     for (int i = lines.Length; i < count; ++i)
                     {
-                        data.Remove(i + 1);
+                        data.Remove(i);
                     }
                 }
             }


### PR DESCRIPTION
Before:
![before](https://github.com/user-attachments/assets/664e41db-9e4b-467d-bd98-23c7384cb8ce)

After:

![after](https://github.com/user-attachments/assets/d198c3d1-c829-4732-a87b-2e0e8223e959)
