### PR TITLE
Unified plugin behavior during bad #pragma between Native and Cobertura reports

### DIFF
--- a/CoverageExt/Cobertura/HandlePragmas.cs
+++ b/CoverageExt/Cobertura/HandlePragmas.cs
@@ -29,12 +29,12 @@ namespace NubiloSoft.CoverageExt.Cobertura
                     {
                         idx += "#pragma ".Length;
                         string t = line.Substring(idx).TrimStart();
-                        if (t.StartsWith("EnableCodeCoverage"))
+                        if (t == "EnableCodeCoverage")
                         {
                             data.Remove(i);
                             enabled = true;
                         }
-                        else if (t.StartsWith("DisableCodeCoverage"))
+                        else if (t == "DisableCodeCoverage")
                         {
                             enabled = false;
                         }


### PR DESCRIPTION
Reopening due to branch mess

Native side:

https://github.com/atlaste/CPPCoverage/blob/9a3cdb788c48763ffad7595a1d3e0d36a4d9ad5b/Coverage/FileInfo.h#L29-L45

Example:

```c++
int main()
{
    std::cout << "Cover line" << std::endl;

    // DisableCodeCoverageD
    std::cout << "Uncover line" << std::endl;
    // EnableCodeCoverageD

    std::cout << "Cover line" << std::endl;
}
```