### PR TITLE
Move the code coverage redraw event.

### DIFF
--- a/CoverageExt/CoverageExecution.cs
+++ b/CoverageExt/CoverageExecution.cs
@@ -387,6 +387,7 @@ namespace NubiloSoft.CoverageExt
                 output.WriteLine("Uncaught error during coverage execution: {0}", ex.Message);
             }
             Data.ReportManagerSingleton.Instance(dte).ResetData();
+            Settings.Instance.TriggerRedraw();
             Interlocked.Exchange(ref running, 0);
         }
 

--- a/CoverageExt/CoverageExtPackage.cs
+++ b/CoverageExt/CoverageExtPackage.cs
@@ -249,8 +249,6 @@ namespace NubiloSoft.CoverageExt
                     outputWindow.WriteLine("Unexpected code coverage failure; error: {0}", ex.ToString());
                 }
             }
-
-            Settings.Instance.TriggerRedraw();
         }
 
         private void FileContextMenuItem_BeforeQueryStatus(object sender, EventArgs e)


### PR DESCRIPTION
Instead of performing a redraw immediately after a thread is started, perform this task after a new report is created.

Redrawing immediately after starting a thread doesn't change anything, based on an old report. There is no need to perform a view refresh if an exception occurred during the process startup.

Behavior similar to enabling right-click code coverage.