### PR TITLE
Fix the search for #pragma DisableCodeCoverage/EnableCodeCoverage.

### DIFF
--- a/Coverage/FileInfo.h
+++ b/Coverage/FileInfo.h
@@ -3,6 +3,7 @@
 #include "FileLineInfo.h"
 #include "RuntimeOptions.h"
 
+#include <algorithm>
 #include <vector>
 #include <string>
 #include <iostream>
@@ -10,6 +11,16 @@
 
 struct FileInfo
 {
+private:
+	static constexpr std::string_view PRAGMA_LINE = "#pragma";
+
+	bool StringStartsWith(const std::string& line, const std::string_view& prefix)
+	{
+		if (line.length() < prefix.length())
+			return false;
+		return std::mismatch(prefix.begin(), prefix.end(), line.begin()).first == prefix.end();
+	}
+public:
 	FileInfo(const std::string& filename)
 	{
 		std::ifstream ifs(filename);
@@ -20,10 +31,10 @@ struct FileInfo
 		while (std::getline(ifs, line))
 		{
 			// Process str
-			size_t idx = line.find("#pragma");
-			if (idx != std::string::npos)
+			line.erase(line.begin(), std::find_if_not(line.begin(), line.end(), std::isspace));
+			if (StringStartsWith(line, PRAGMA_LINE))
 			{
-				size_t jdx = line.find_first_not_of(' ', idx + 7);
+				size_t jdx = line.find_first_not_of(' ', PRAGMA_LINE.length());
 				if (jdx != std::string::npos)
 				{
 					std::string prag = line.substr(jdx);

--- a/CoverageExt/Cobertura/HandlePragmas.cs
+++ b/CoverageExt/Cobertura/HandlePragmas.cs
@@ -14,6 +14,8 @@ namespace NubiloSoft.CoverageExt.Cobertura
     /// </summary>
     public class HandlePragmas
     {
+        private static readonly string PRAGMA_LINE = "#pragma";
+
         public static void Update(string filename, BitVector data)
         {
             bool enabled = true;
@@ -23,11 +25,10 @@ namespace NubiloSoft.CoverageExt.Cobertura
                 string[] lines = File.ReadAllLines(filename);
                 for (int i = 0; i < lines.Length; ++i)
                 {
-                    string line = lines[i];
-                    int idx = line.IndexOf("#pragma");
-                    if (idx >= 0)
+                    string line = lines[i].TrimStart();
+                    if (line.StartsWith(PRAGMA_LINE))
                     {
-                        idx += "#pragma ".Length;
+                        int idx = PRAGMA_LINE.Length;
                         string t = line.Substring(idx).TrimStart();
                         if (t == "EnableCodeCoverage")
                         {


### PR DESCRIPTION
Allow only whitespace before Pragma.
See https://github.com/atlaste/CPPCoverage/pull/58#discussion_r1967333332