### PR TITLE
CoverageExecution: simplifying prepare arguments

### DIFF
--- a/CoverageExt/CoverageExecution.cs
+++ b/CoverageExt/CoverageExecution.cs
@@ -40,6 +40,58 @@ namespace NubiloSoft.CoverageExt
             }
         }
 
+        private string CreateVsTestExePath()
+        {
+            // TODO: We can do much better here by using the registry...
+            var folders = new[]
+            {
+                @"\Microsoft Visual Studio\2022\Professional\Common7\IDE\Extensions\TestPlatform\",
+                @"\Microsoft Visual Studio\2022\Community\Common7\IDE\Extensions\TestPlatform\",
+                @"\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\Extensions\TestPlatform\",
+                @"\Microsoft Visual Studio\2022\BuildTools\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
+                @"\Microsoft Visual Studio\2019\Community\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
+                @"\Microsoft Visual Studio\2019\Professional\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
+                @"\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
+                @"\Microsoft Visual Studio\2019\BuildTools\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
+                @"\Microsoft Visual Studio\2017\Community\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
+                @"\Microsoft Visual Studio\2017\Professional\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
+                @"\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
+                @"\Microsoft Visual Studio\2017\BuildTools\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
+                @"\Microsoft Visual Studio 19.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
+                @"\Microsoft Visual Studio 16.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
+                @"\Microsoft Visual Studio 15.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
+                @"\Microsoft Visual Studio 14.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
+                @"\Microsoft Visual Studio 13.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\"
+            };
+            var pf = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86).TrimEnd('\\');
+
+            foreach (var fold in folders)
+            {
+                string file = pf + fold + "vstest.console.exe";
+                if (File.Exists(file))
+                {
+                    this.output.WriteLine("Found vstest console app.");
+                    return file;
+                }
+            }
+
+            pf = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles).TrimEnd('\\');
+            this.output.WriteLine(pf);
+
+            foreach (var fold in folders)
+            {
+                string file = pf + fold + "vstest.console.exe";
+                this.output.WriteLine(file);
+                if (File.Exists(file))
+                {
+                    this.output.WriteLine("Found vstest console app.");
+                    return file;
+                }
+            }
+
+            throw new Exception("Cannot find vstest.console.exe.");
+        }
+
         private void StartImpl(string solutionFolder, string platform, string dllFolder, string dllFilename, string workingDirectory, string commandline)
         {
             try
@@ -113,70 +165,11 @@ namespace NubiloSoft.CoverageExt
                     }
                     else
                     {
-                        // TODO: We can do much better here by using the registry...
-                        var folders = new[]
-                        {
-                            @"\Microsoft Visual Studio\2022\Professional\Common7\IDE\Extensions\TestPlatform\",
-                            @"\Microsoft Visual Studio\2022\Community\Common7\IDE\Extensions\TestPlatform\",
-                            @"\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\Extensions\TestPlatform\",
-                            @"\Microsoft Visual Studio\2022\BuildTools\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
-                            @"\Microsoft Visual Studio\2019\Community\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
-                            @"\Microsoft Visual Studio\2019\Professional\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
-                            @"\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
-                            @"\Microsoft Visual Studio\2019\BuildTools\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
-                            @"\Microsoft Visual Studio\2017\Community\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
-                            @"\Microsoft Visual Studio\2017\Professional\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
-                            @"\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
-                            @"\Microsoft Visual Studio\2017\BuildTools\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
-                            @"\Microsoft Visual Studio 19.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
-                            @"\Microsoft Visual Studio 16.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
-                            @"\Microsoft Visual Studio 15.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
-                            @"\Microsoft Visual Studio 14.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\",
-                            @"\Microsoft Visual Studio 13.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\"
-                        };
-                        var pf = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86).TrimEnd('\\');
-
-                        var foundtestConsole = false;
-                        string filename = null;
-                        foreach (var fold in folders)
-                        {
-                            string file = pf + fold + "vstest.console.exe";
-                            if (File.Exists(file))
-                            {
-                                filename = file;
-                                this.output.WriteLine("Found vstest console app.");
-                                foundtestConsole = true;
-                                break;
-                            }
-                        }
-
-                        if (foundtestConsole == false)
-                        {
-                            pf = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles).TrimEnd('\\');
-                            this.output.WriteLine(pf);
-                            
-                            filename = null;
-                            foreach (var fold in folders)
-                            {
-                                string file = pf + fold + "vstest.console.exe";
-                                this.output.WriteLine(file);
-                                if (File.Exists(file))
-                                {
-                                    filename = file;
-                                    this.output.WriteLine("Found vstest console app.");
-                                    foundtestConsole = true;
-                                    break;
-                                }
-                                else
-                                {
-                                    this.output.WriteLine("Cannot find vstest.console.exe.");
-                                }
-                            }
-                        }
+                        string vsTestExe = CreateVsTestExePath();
 
                         argumentBuilder.Append("\" -- ");
                         // C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe
-                        argumentBuilder.Append(@"""" + filename + @"""");
+                        argumentBuilder.Append(@"""" + vsTestExe + @"""");
                         argumentBuilder.Append(" /Platform:" + platform + " \"");
                     }
 

--- a/CoverageExt/CoverageExecution.cs
+++ b/CoverageExt/CoverageExecution.cs
@@ -159,15 +159,11 @@ namespace NubiloSoft.CoverageExt
                         argumentBuilder.Append(PathWithQuotes(workingDirectory));
                     }
 
-                    if (dllFilename.EndsWith(".exe", StringComparison.InvariantCultureIgnoreCase))
-                    {
-                        argumentBuilder.Append(" -- ");
-                    }
-                    else
+                    argumentBuilder.Append(" -- ");
+
+                    if (!dllFilename.EndsWith(".exe", StringComparison.InvariantCultureIgnoreCase))
                     {
                         string vsTestExe = CreateVsTestExePath();
-
-                        argumentBuilder.Append(" -- ");
                         argumentBuilder.Append(PathWithQuotes(vsTestExe));
                         argumentBuilder.Append(" /Platform:" + platform + " ");
                     }
@@ -281,30 +277,22 @@ namespace NubiloSoft.CoverageExt
                     }
 
                     StringBuilder argumentBuilder = new StringBuilder();
-                    if (dllFilename.EndsWith(".exe", StringComparison.InvariantCultureIgnoreCase))
-                    {
-                        argumentBuilder.Append("--quiet --export_type cobertura:");
-                        argumentBuilder.Append(PathWithQuotes(resultFile));
-                        argumentBuilder.Append(" --continue_after_cpp_exception --cover_children ");
-                        argumentBuilder.Append("--sources ");
-                        argumentBuilder.Append(sourcesFilter);
-                        argumentBuilder.Append(" -- ");
-                        argumentBuilder.Append(PathWithQuotes(Path.Combine(dllFolder, dllFilename)));
-                    }
-                    else
-                    {
-                        argumentBuilder.Append("--quiet --export_type cobertura:");
-                        argumentBuilder.Append(PathWithQuotes(resultFile));
-                        argumentBuilder.Append(" --continue_after_cpp_exception --cover_children ");
-                        argumentBuilder.Append("--sources ");
-                        argumentBuilder.Append(sourcesFilter);
-                        argumentBuilder.Append(" -- ");
 
+                    argumentBuilder.Append("--quiet --export_type cobertura:");
+                    argumentBuilder.Append(PathWithQuotes(resultFile));
+                    argumentBuilder.Append(" --continue_after_cpp_exception --cover_children ");
+                    argumentBuilder.Append("--sources ");
+                    argumentBuilder.Append(sourcesFilter);
+                    argumentBuilder.Append(" -- ");
+
+                    if (!dllFilename.EndsWith(".exe", StringComparison.InvariantCultureIgnoreCase))
+                    {
                         string vsTestExe = CreateVsTestExePath();
                         argumentBuilder.Append(PathWithQuotes(vsTestExe));
                         argumentBuilder.Append(" /Platform:" + platform + " ");
-                        argumentBuilder.Append(PathWithQuotes(Path.Combine(dllFolder, dllFilename)));
                     }
+
+                    argumentBuilder.Append(PathWithQuotes(Path.Combine(dllFolder, dllFilename)));
 
 #if DEBUG
                     this.output.WriteLine("Execute coverage: {0}", argumentBuilder.ToString());

--- a/CoverageExt/CoverageExecution.cs
+++ b/CoverageExt/CoverageExecution.cs
@@ -150,7 +150,7 @@ namespace NubiloSoft.CoverageExt
                     argumentBuilder.Append(" -p ");
                     argumentBuilder.Append(PathWithQuotes(solutionFolder.TrimEnd('\\', '/')));
 
-                    if (workingDirectory != null && workingDirectory.Length > 0)
+                    if (!String.IsNullOrEmpty(workingDirectory))
                     {
                         // When directory finish by \ : c++ read \" and arguments is badly computed !
                         workingDirectory = workingDirectory.TrimEnd('\\', '/');
@@ -173,7 +173,7 @@ namespace NubiloSoft.CoverageExt
                     }
 
                     argumentBuilder.Append(PathWithQuotes(Path.Combine(dllFolder, dllFilename)));
-                    if (commandline != null && commandline.Length > 0)
+                    if (!String.IsNullOrEmpty(commandline))
                     {
                         argumentBuilder.Append(" ");
                         argumentBuilder.Append(commandline);

--- a/CoverageExt/CoverageExecution.cs
+++ b/CoverageExt/CoverageExecution.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Text;
 using System.Threading;
 using DTE = EnvDTE.DTE;
-//using Process = EnvDTE.Process;
 
 namespace NubiloSoft.CoverageExt
 {
@@ -16,7 +15,6 @@ namespace NubiloSoft.CoverageExt
             this.output = output;
         }
 
-        private StringBuilder sb = new StringBuilder();
         private StringBuilder tb = new StringBuilder();
         private DateTime lastEvent = DateTime.UtcNow;
 

--- a/CoverageExt/CoverageExecution.cs
+++ b/CoverageExt/CoverageExecution.cs
@@ -23,6 +23,11 @@ namespace NubiloSoft.CoverageExt
 
         private int running = 0;
 
+        private static string PathWithQuotes( string path )
+        {
+            return @"""" + path + @"""";
+        }
+
         public void Start(string solutionFolder, string platform, string dllFolder, string dllFilename, string workingDirectory, string commandline)
         {
             // We want 1 thread to do this; never more.
@@ -140,47 +145,38 @@ namespace NubiloSoft.CoverageExt
 
                     StringBuilder argumentBuilder = new StringBuilder();
 
-                    argumentBuilder.Append("-o \"");
-                    argumentBuilder.Append(resultFile);
-                    argumentBuilder.Append("\" -p \"");
-                    argumentBuilder.Append(solutionFolder.TrimEnd('\\', '/'));
+                    argumentBuilder.Append("-o ");
+                    argumentBuilder.Append(PathWithQuotes(resultFile));
+                    argumentBuilder.Append(" -p ");
+                    argumentBuilder.Append(PathWithQuotes(solutionFolder.TrimEnd('\\', '/')));
 
                     if (workingDirectory != null && workingDirectory.Length > 0)
                     {
                         // When directory finish by \ : c++ read \" and arguments is badly computed !
                         workingDirectory = workingDirectory.TrimEnd('\\', '/');
 
-                        argumentBuilder.Append("\" -w \"");
-                        argumentBuilder.Append(workingDirectory);
-
-                    }
-                    else
-                    {
-                        argumentBuilder.Append("\"");
+                        argumentBuilder.Append(" -w ");
+                        argumentBuilder.Append(PathWithQuotes(workingDirectory));
                     }
 
                     if (dllFilename.EndsWith(".exe", StringComparison.InvariantCultureIgnoreCase))
                     {
-                        argumentBuilder.Append("\" -- \"");
+                        argumentBuilder.Append(" -- ");
                     }
                     else
                     {
                         string vsTestExe = CreateVsTestExePath();
 
-                        argumentBuilder.Append("\" -- ");
-                        argumentBuilder.Append(@"""" + vsTestExe + @"""");
-                        argumentBuilder.Append(" /Platform:" + platform + " \"");
+                        argumentBuilder.Append(" -- ");
+                        argumentBuilder.Append(PathWithQuotes(vsTestExe));
+                        argumentBuilder.Append(" /Platform:" + platform + " ");
                     }
 
-                    argumentBuilder.Append(Path.Combine(dllFolder, dllFilename));
+                    argumentBuilder.Append(PathWithQuotes(Path.Combine(dllFolder, dllFilename)));
                     if (commandline != null && commandline.Length > 0)
                     {
-                        argumentBuilder.Append("\" ");
+                        argumentBuilder.Append(" ");
                         argumentBuilder.Append(commandline);
-                    }
-                    else
-                    {
-                        argumentBuilder.Append("\"");
                     }
 
 #if DEBUG
@@ -287,29 +283,27 @@ namespace NubiloSoft.CoverageExt
                     StringBuilder argumentBuilder = new StringBuilder();
                     if (dllFilename.EndsWith(".exe", StringComparison.InvariantCultureIgnoreCase))
                     {
-                        argumentBuilder.Append("--quiet --export_type cobertura:\"");
-                        argumentBuilder.Append(resultFile);
-                        argumentBuilder.Append("\" --continue_after_cpp_exception --cover_children ");
+                        argumentBuilder.Append("--quiet --export_type cobertura:");
+                        argumentBuilder.Append(PathWithQuotes(resultFile));
+                        argumentBuilder.Append(" --continue_after_cpp_exception --cover_children ");
                         argumentBuilder.Append("--sources ");
                         argumentBuilder.Append(sourcesFilter);
-                        argumentBuilder.Append(" -- \"");
-                        argumentBuilder.Append(Path.Combine(dllFolder, dllFilename));
-                        argumentBuilder.Append("\"");
+                        argumentBuilder.Append(" -- ");
+                        argumentBuilder.Append(PathWithQuotes(Path.Combine(dllFolder, dllFilename)));
                     }
                     else
                     {
-                        argumentBuilder.Append("--quiet --export_type cobertura:\"");
-                        argumentBuilder.Append(resultFile);
-                        argumentBuilder.Append("\" --continue_after_cpp_exception --cover_children ");
+                        argumentBuilder.Append("--quiet --export_type cobertura:");
+                        argumentBuilder.Append(PathWithQuotes(resultFile));
+                        argumentBuilder.Append(" --continue_after_cpp_exception --cover_children ");
                         argumentBuilder.Append("--sources ");
                         argumentBuilder.Append(sourcesFilter);
                         argumentBuilder.Append(" -- ");
 
                         string vsTestExe = CreateVsTestExePath();
-                        argumentBuilder.Append(@"""" + vsTestExe + @"""");
-                        argumentBuilder.Append(" /Platform:" + platform + " \"");
-                        argumentBuilder.Append(Path.Combine(dllFolder, dllFilename));
-                        argumentBuilder.Append("\"");
+                        argumentBuilder.Append(PathWithQuotes(vsTestExe));
+                        argumentBuilder.Append(" /Platform:" + platform + " ");
+                        argumentBuilder.Append(PathWithQuotes(Path.Combine(dllFolder, dllFilename)));
                     }
 
 #if DEBUG

--- a/CoverageExt/CoverageExecution.cs
+++ b/CoverageExt/CoverageExecution.cs
@@ -168,7 +168,6 @@ namespace NubiloSoft.CoverageExt
                         string vsTestExe = CreateVsTestExePath();
 
                         argumentBuilder.Append("\" -- ");
-                        // C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe
                         argumentBuilder.Append(@"""" + vsTestExe + @"""");
                         argumentBuilder.Append(" /Platform:" + platform + " \"");
                     }
@@ -305,7 +304,9 @@ namespace NubiloSoft.CoverageExt
                         argumentBuilder.Append("--sources ");
                         argumentBuilder.Append(sourcesFilter);
                         argumentBuilder.Append(" -- ");
-                        argumentBuilder.Append(@"""C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe""");
+
+                        string vsTestExe = CreateVsTestExePath();
+                        argumentBuilder.Append(@"""" + vsTestExe + @"""");
                         argumentBuilder.Append(" /Platform:" + platform + " \"");
                         argumentBuilder.Append(Path.Combine(dllFolder, dllFilename));
                         argumentBuilder.Append("\"");


### PR DESCRIPTION
Create local PathWithQuotes function to add quotes for path. Simplifying prepare arguments for native and cobertura coverage.
It depends on #64.