### PR TITLE
Fixed compiling the project before running code coverage.

### DIFF
--- a/CoverageExt/CoverageExtPackage.cs
+++ b/CoverageExt/CoverageExtPackage.cs
@@ -174,7 +174,8 @@ namespace NubiloSoft.CoverageExt
                         {
                             if (Settings.Instance.CompileBeforeRunning)
                             {
-                                var projectBuilder = new ProjectBuilder(dte, outputWindow, project.UniqueName, vcproj.ActiveConfiguration.Name,
+                                var solutionConfiguration = dte.Solution.Properties.Item("ActiveConfig").Value.ToString();
+                                var projectBuilder = new ProjectBuilder(dte, outputWindow, project.UniqueName, solutionConfiguration,
                                     () => RunCoverage(dte, outputWindow, vcproj));
                                 projectBuilder.Build();
                             }


### PR DESCRIPTION
The BuildProject method requires the solution configuration, not the project configuration. The problem occurs when the solution configuration has been set to x86, but the project has a Win32 configuration.