### PR TITLE
CoverageExecution: preparing arguments in a separate method

### DIFF
--- a/CoverageExt/CoverageExecution.cs
+++ b/CoverageExt/CoverageExecution.cs
@@ -48,6 +48,14 @@ namespace NubiloSoft.CoverageExt
             }
         }
 
+        private (string, string) CoverageReportPaths( string solutionFolder )
+        {
+            string ext = Settings.Instance.UseNativeCoverageSupport ? ".cov" : ".xml";
+            string resPathBase = Path.Combine(solutionFolder, "CodeCoverage" + ext);
+            string tmpPathBase = Path.Combine(solutionFolder, "CodeCoverage.tmp" + ext);
+            return (resPathBase, tmpPathBase);
+        }
+
         private string CoverageExePath( string platform )
         {
             if (Settings.Instance.UseNativeCoverageSupport)
@@ -133,11 +141,10 @@ namespace NubiloSoft.CoverageExt
                 if (Settings.Instance.UseNativeCoverageSupport)
                 {
                     // Delete old coverage file
-                    string resultFile = Path.Combine(solutionFolder, "CodeCoverage.tmp.cov");
-                    string defResultFile = Path.Combine(solutionFolder, "CodeCoverage.cov");
-                    if (File.Exists(resultFile))
+                    (string resultFile, string tempFile) = CoverageReportPaths(solutionFolder);
+                    if (File.Exists(tempFile))
                     {
-                        File.Delete(resultFile);
+                        File.Delete(tempFile);
                     }
 
                     // Create your Process
@@ -164,7 +171,7 @@ namespace NubiloSoft.CoverageExt
                     StringBuilder argumentBuilder = new StringBuilder();
 
                     argumentBuilder.Append("-o ");
-                    argumentBuilder.Append(PathWithQuotes(resultFile));
+                    argumentBuilder.Append(PathWithQuotes(tempFile));
                     argumentBuilder.Append(" -p ");
                     argumentBuilder.Append(PathWithQuotes(solutionFolder.TrimEnd('\\', '/')));
 
@@ -237,14 +244,14 @@ namespace NubiloSoft.CoverageExt
                         throw new Exception("Cannot find test source file " + dllFilename);
                     }
 
-                    if (File.Exists(resultFile))
+                    if (File.Exists(tempFile))
                     {
                         // All fine, update file:
-                        if (File.Exists(defResultFile))
+                        if (File.Exists(resultFile))
                         {
-                            File.Delete(defResultFile);
+                            File.Delete(resultFile);
                         }
-                        File.Move(resultFile, defResultFile);
+                        File.Move(tempFile, resultFile);
                     }
                     else
                     {
@@ -254,11 +261,10 @@ namespace NubiloSoft.CoverageExt
                 else
                 {
                     // Delete old coverage file
-                    string resultFile = Path.Combine(solutionFolder, "CodeCoverage.tmp.xml");
-                    string defResultFile = Path.Combine(solutionFolder, "CodeCoverage.xml");
-                    if (File.Exists(resultFile))
+                    (string resultFile, string tempFile) = CoverageReportPaths(solutionFolder);
+                    if (File.Exists(tempFile))
                     {
-                        File.Delete(resultFile);
+                        File.Delete(tempFile);
                     }
 
                     // Create your Process
@@ -285,7 +291,7 @@ namespace NubiloSoft.CoverageExt
                     StringBuilder argumentBuilder = new StringBuilder();
 
                     argumentBuilder.Append("--quiet --export_type cobertura:");
-                    argumentBuilder.Append(PathWithQuotes(resultFile));
+                    argumentBuilder.Append(PathWithQuotes(tempFile));
                     argumentBuilder.Append(" --continue_after_cpp_exception --cover_children ");
                     argumentBuilder.Append("--sources ");
                     argumentBuilder.Append(sourcesFilter);
@@ -309,7 +315,7 @@ namespace NubiloSoft.CoverageExt
                     this.output.WriteLine("Execute coverage: {0}", argumentBuilder.ToString());
 #endif
 
-                    process.StartInfo.WorkingDirectory = Path.GetDirectoryName(resultFile);
+                    process.StartInfo.WorkingDirectory = Path.GetDirectoryName(tempFile);
                     process.StartInfo.Arguments = argumentBuilder.ToString();
                     process.StartInfo.CreateNoWindow = true;
                     process.StartInfo.UseShellExecute = false;
@@ -349,14 +355,14 @@ namespace NubiloSoft.CoverageExt
                         throw new Exception("Cannot find test source file " + dllFilename);
                     }
 
-                    if (File.Exists(resultFile))
+                    if (File.Exists(tempFile))
                     {
                         // All fine, update file:
-                        if (File.Exists(defResultFile))
+                        if (File.Exists(resultFile))
                         {
-                            File.Delete(defResultFile);
+                            File.Delete(resultFile);
                         }
-                        File.Move(resultFile, defResultFile);
+                        File.Move(tempFile, resultFile);
                     }
                     else
                     {

--- a/CoverageExt/CoverageExecution.cs
+++ b/CoverageExt/CoverageExecution.cs
@@ -134,6 +134,66 @@ namespace NubiloSoft.CoverageExt
             throw new Exception("Cannot find vstest.console.exe.");
         }
 
+        private string PrepareArguments( string solutionFolder, string platform, string dllPath, string workingDirectory, string commandline, string reportFile )
+        {
+            StringBuilder argumentBuilder = new StringBuilder();
+
+            if (Settings.Instance.UseNativeCoverageSupport)
+            {
+                argumentBuilder.Append("-o ");
+                argumentBuilder.Append(PathWithQuotes(reportFile));
+                argumentBuilder.Append(" -p ");
+                argumentBuilder.Append(PathWithQuotes(solutionFolder.TrimEnd('\\', '/')));
+
+                if (!String.IsNullOrEmpty(workingDirectory))
+                {
+                    // When directory finish by \ : c++ read \" and arguments is badly computed !
+                    workingDirectory = workingDirectory.TrimEnd('\\', '/');
+
+                    argumentBuilder.Append(" -w ");
+                    argumentBuilder.Append(PathWithQuotes(workingDirectory));
+                }
+            }
+            else
+            {
+                string sourcesFilter = solutionFolder;
+                int smidx = sourcesFilter.IndexOf(' ');
+                if (smidx > 0)
+                {
+                    sourcesFilter = sourcesFilter.Substring(0, smidx);
+                    int lidx = sourcesFilter.LastIndexOf('\\');
+                    if (lidx >= 0)
+                    {
+                        sourcesFilter = sourcesFilter.Substring(0, lidx - 1);
+                    }
+                }
+
+                argumentBuilder.Append("--quiet --export_type cobertura:");
+                argumentBuilder.Append(PathWithQuotes(reportFile));
+                argumentBuilder.Append(" --continue_after_cpp_exception --cover_children ");
+                argumentBuilder.Append("--sources ");
+                argumentBuilder.Append(sourcesFilter);
+            }
+
+            argumentBuilder.Append(" -- ");
+
+            if (!dllPath.EndsWith(".exe", StringComparison.InvariantCultureIgnoreCase))
+            {
+                string vsTestExe = CreateVsTestExePath();
+                argumentBuilder.Append(PathWithQuotes(vsTestExe));
+                argumentBuilder.Append(" /Platform:" + platform + " ");
+            }
+
+            argumentBuilder.Append(PathWithQuotes(dllPath));
+            if (!String.IsNullOrEmpty(commandline))
+            {
+                argumentBuilder.Append(" ");
+                argumentBuilder.Append(commandline);
+            }
+
+            return argumentBuilder.ToString();
+        }
+
         private void StartImpl(string solutionFolder, string platform, string dllFolder, string dllFilename, string workingDirectory, string commandline)
         {
             try
@@ -157,56 +217,13 @@ namespace NubiloSoft.CoverageExt
                         throw new NotSupportedException(filename + " was not found. Expected: " + process.StartInfo.FileName);
                     }
 
-                    string sourcesFilter = solutionFolder;
-                    int smidx = sourcesFilter.IndexOf(' ');
-                    if (smidx > 0)
-                    {
-                        sourcesFilter = sourcesFilter.Substring(0, smidx);
-                        int lidx = sourcesFilter.LastIndexOf('\\');
-                        if (lidx >= 0)
-                        {
-                            sourcesFilter = sourcesFilter.Substring(0, lidx - 1);
-                        }
-                    }
-
-                    StringBuilder argumentBuilder = new StringBuilder();
-
-                    argumentBuilder.Append("-o ");
-                    argumentBuilder.Append(PathWithQuotes(tempFile));
-                    argumentBuilder.Append(" -p ");
-                    argumentBuilder.Append(PathWithQuotes(solutionFolder.TrimEnd('\\', '/')));
-
-                    if (!String.IsNullOrEmpty(workingDirectory))
-                    {
-                        // When directory finish by \ : c++ read \" and arguments is badly computed !
-                        workingDirectory = workingDirectory.TrimEnd('\\', '/');
-
-                        argumentBuilder.Append(" -w ");
-                        argumentBuilder.Append(PathWithQuotes(workingDirectory));
-                    }
-
-                    argumentBuilder.Append(" -- ");
-
-                    if (!dllFilename.EndsWith(".exe", StringComparison.InvariantCultureIgnoreCase))
-                    {
-                        string vsTestExe = CreateVsTestExePath();
-                        argumentBuilder.Append(PathWithQuotes(vsTestExe));
-                        argumentBuilder.Append(" /Platform:" + platform + " ");
-                    }
-
-                    argumentBuilder.Append(PathWithQuotes(Path.Combine(dllFolder, dllFilename)));
-                    if (!String.IsNullOrEmpty(commandline))
-                    {
-                        argumentBuilder.Append(" ");
-                        argumentBuilder.Append(commandline);
-                    }
-
+                    string arguments = PrepareArguments(solutionFolder, platform, Path.Combine(dllFolder, dllFilename), workingDirectory, commandline, tempFile);
 #if DEBUG
-                    this.output.WriteLine("Execute coverage: {0}", argumentBuilder.ToString());
+                    this.output.WriteLine("Execute coverage: {0}", arguments);
 #endif
 
                     process.StartInfo.WorkingDirectory = dllFolder;
-                    process.StartInfo.Arguments = argumentBuilder.ToString();
+                    process.StartInfo.Arguments = arguments;
                     process.StartInfo.CreateNoWindow = true;
                     process.StartInfo.UseShellExecute = false;
                     process.StartInfo.RedirectStandardOutput = true;
@@ -278,47 +295,13 @@ namespace NubiloSoft.CoverageExt
                         throw new NotSupportedException(filename + " was not found. Expected: " + process.StartInfo.FileName);
                     }
 
-                    string sourcesFilter = solutionFolder;
-                    int smidx = sourcesFilter.IndexOf(' ');
-                    if (smidx > 0)
-                    {
-                        sourcesFilter = sourcesFilter.Substring(0, smidx);
-                        int lidx = sourcesFilter.LastIndexOf('\\');
-                        if (lidx >= 0)
-                        {
-                            sourcesFilter = sourcesFilter.Substring(0, lidx - 1);
-                        }
-                    }
-
-                    StringBuilder argumentBuilder = new StringBuilder();
-
-                    argumentBuilder.Append("--quiet --export_type cobertura:");
-                    argumentBuilder.Append(PathWithQuotes(tempFile));
-                    argumentBuilder.Append(" --continue_after_cpp_exception --cover_children ");
-                    argumentBuilder.Append("--sources ");
-                    argumentBuilder.Append(sourcesFilter);
-                    argumentBuilder.Append(" -- ");
-
-                    if (!dllFilename.EndsWith(".exe", StringComparison.InvariantCultureIgnoreCase))
-                    {
-                        string vsTestExe = CreateVsTestExePath();
-                        argumentBuilder.Append(PathWithQuotes(vsTestExe));
-                        argumentBuilder.Append(" /Platform:" + platform + " ");
-                    }
-
-                    argumentBuilder.Append(PathWithQuotes(Path.Combine(dllFolder, dllFilename)));
-                    if (!String.IsNullOrEmpty(commandline))
-                    {
-                        argumentBuilder.Append(" ");
-                        argumentBuilder.Append(commandline);
-                    }
-
+                    string arguments = PrepareArguments(solutionFolder, platform, Path.Combine(dllFolder, dllFilename), workingDirectory, commandline, tempFile);
 #if DEBUG
-                    this.output.WriteLine("Execute coverage: {0}", argumentBuilder.ToString());
+                    this.output.WriteLine("Execute coverage: {0}", arguments);
 #endif
 
                     process.StartInfo.WorkingDirectory = Path.GetDirectoryName(tempFile);
-                    process.StartInfo.Arguments = argumentBuilder.ToString();
+                    process.StartInfo.Arguments = arguments;
                     process.StartInfo.CreateNoWindow = true;
                     process.StartInfo.UseShellExecute = false;
                     process.StartInfo.RedirectStandardOutput = true;

--- a/CoverageExt/CoverageExecution.cs
+++ b/CoverageExt/CoverageExecution.cs
@@ -153,7 +153,8 @@ namespace NubiloSoft.CoverageExt
 
                     if (!File.Exists(process.StartInfo.FileName))
                     {
-                        throw new NotSupportedException("Coverage.exe instance for platform was not found. Expected: " + process.StartInfo.FileName);
+                        string filename = Path.GetFileName(process.StartInfo.FileName);
+                        throw new NotSupportedException(filename + " was not found. Expected: " + process.StartInfo.FileName);
                     }
 
                     string sourcesFilter = solutionFolder;
@@ -273,7 +274,8 @@ namespace NubiloSoft.CoverageExt
 
                     if (!File.Exists(process.StartInfo.FileName))
                     {
-                        throw new NotSupportedException("OpenCPPCoverage was not found. Expected: " + process.StartInfo.FileName);
+                        string filename = Path.GetFileName(process.StartInfo.FileName);
+                        throw new NotSupportedException(filename + " was not found. Expected: " + process.StartInfo.FileName);
                     }
 
                     string sourcesFilter = solutionFolder;


### PR DESCRIPTION
This is the third PR in a series of changes related to source code reduction - moving the argument preparer to a separate method.
It depends on #69.