### PR TITLE
Update settings only after approving changes.

### DIFF
--- a/CoverageExt/CoverageExtPackage.cs
+++ b/CoverageExt/CoverageExtPackage.cs
@@ -60,6 +60,7 @@ namespace NubiloSoft.CoverageExt
 
             // this forces the options to be loaded, since it call the Load function on the OptionPageGrid
             GeneralOptionPageGrid page = (GeneralOptionPageGrid)GetDialogPage(typeof(GeneralOptionPageGrid));
+            page.UpdateSettings();
 
             // Add our command handlers for menu (commands must exist in the .vsct file)
             if (await GetServiceAsync(typeof(IMenuCommandService)) is OleMenuCommandService mcs)

--- a/CoverageExt/GeneralOptionPageGrid.cs
+++ b/CoverageExt/GeneralOptionPageGrid.cs
@@ -59,15 +59,9 @@ namespace NubiloSoft.CoverageExt
         [TypeConverter(typeof(CustomColorConverter))]
         public Color CoveredPen { get; set; } = Color.FromArgb(0xD0, 0xBD, 0xFC, 0xBF);
 
-        public override void LoadSettingsFromStorage()
+        protected override void OnApply( PageApplyEventArgs e )
         {
-            base.LoadSettingsFromStorage();
-            UpdateSettings();
-        }
-
-        public override void SaveSettingsToStorage()
-        {
-            base.SaveSettingsToStorage();
+            base.OnApply(e);
             UpdateSettings();
         }
 


### PR DESCRIPTION
The LoadSettingsFromStorage and SaveSettingsToStorage methods are used on various occasions, including when VisualStudio is closed. Update settings only when changing settings and accepting them.