### PR TITLE
Implement WriteDebugLine method for OutputWindow.

### DIFF
--- a/CoverageExt/CoverageExecution.cs
+++ b/CoverageExt/CoverageExecution.cs
@@ -218,9 +218,7 @@ namespace NubiloSoft.CoverageExt
                     }
 
                     string arguments = PrepareArguments(solutionFolder, platform, Path.Combine(dllFolder, dllFilename), workingDirectory, commandline, tempFile);
-#if DEBUG
-                    this.output.WriteLine("Execute coverage: {0}", arguments);
-#endif
+                    this.output.WriteDebugLine("Execute coverage: {0}", arguments);
 
                     process.StartInfo.WorkingDirectory = dllFolder;
                     process.StartInfo.Arguments = arguments;
@@ -296,9 +294,7 @@ namespace NubiloSoft.CoverageExt
                     }
 
                     string arguments = PrepareArguments(solutionFolder, platform, Path.Combine(dllFolder, dllFilename), workingDirectory, commandline, tempFile);
-#if DEBUG
-                    this.output.WriteLine("Execute coverage: {0}", arguments);
-#endif
+                    this.output.WriteDebugLine("Execute coverage: {0}", arguments);
 
                     process.StartInfo.WorkingDirectory = Path.GetDirectoryName(tempFile);
                     process.StartInfo.Arguments = arguments;

--- a/CoverageExt/OutputWindow.cs
+++ b/CoverageExt/OutputWindow.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using EnvDTE;
+﻿using EnvDTE;
 using EnvDTE80;
 
 namespace NubiloSoft.CoverageExt
@@ -66,6 +61,13 @@ namespace NubiloSoft.CoverageExt
                     window.OutputString(string.Format(format, par) + "\r\n");
                 }
             }
+        }
+
+        public void WriteDebugLine(string format, params object[] par)
+        {
+#if DEBUG
+            WriteLine(format, par);
+#endif
         }
     }
 }


### PR DESCRIPTION
With this method, the code becomes a little clearer. It also makes it possible to put such lines in other places in the future.