### PR TITLE
Generate a setting change event after all values are set.

### DIFF
--- a/CoverageExt/CodeRendering/CodeCoverage.cs
+++ b/CoverageExt/CodeRendering/CodeCoverage.cs
@@ -58,7 +58,7 @@ namespace NubiloSoft.CoverageExt.CodeRendering
             {
                 // listen to events that change the setting properties
                 Settings.Instance.OnShowCodeCoveragePropertyChanged += Instance_OnShowCodeCoveragePropertyChanged;
-                Settings.Instance.OnColorPropertyChanged += Instance_OnColorPropertyChanged;
+                Settings.Instance.OnSettingsChanged += Instance_OnSettingsChanged;
                 Settings.Instance.RedrawNeeded += Instance_OnRedrawNeeded;
 
                 // Listen to any event that changes the layout (text changes, scrolling, etc)
@@ -67,7 +67,7 @@ namespace NubiloSoft.CoverageExt.CodeRendering
             else
             {
                 Settings.Instance.OnShowCodeCoveragePropertyChanged -= Instance_OnShowCodeCoveragePropertyChanged;
-                Settings.Instance.OnColorPropertyChanged -= Instance_OnColorPropertyChanged;
+                Settings.Instance.OnSettingsChanged -= Instance_OnSettingsChanged;
                 Settings.Instance.RedrawNeeded -= Instance_OnRedrawNeeded;
                 view.LayoutChanged -= OnLayoutChanged;
             }
@@ -111,9 +111,9 @@ namespace NubiloSoft.CoverageExt.CodeRendering
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void Instance_OnColorPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        private void Instance_OnSettingsChanged(object sender, EventArgs e)
         {
-            this.outputWindow.WriteDebugLine("Instance_OnColorPropertyChanged");
+            this.outputWindow.WriteDebugLine("Instance_OnSettingsChanged");
             InitializeColors();
             Redraw();
         }

--- a/CoverageExt/CodeRendering/CodeCoverage.cs
+++ b/CoverageExt/CodeRendering/CodeCoverage.cs
@@ -33,6 +33,7 @@ namespace NubiloSoft.CoverageExt.CodeRendering
         internal Pen coveredPen;
 
         private EnvDTE.DTE dte;
+        private OutputWindow outputWindow;
 
         private CoverageState[] currentCoverage;
         private ProfileVector currentProfile;
@@ -40,6 +41,7 @@ namespace NubiloSoft.CoverageExt.CodeRendering
         public CodeCoverage(IWpfTextView view, EnvDTE.DTE dte)
         {
             this.dte = dte;
+            this.outputWindow = new OutputWindow(dte);
             this.view = view;
             this.layer = view.GetAdornmentLayer("CodeCoverage");
             this.layer.Opacity = 0.4;
@@ -100,6 +102,7 @@ namespace NubiloSoft.CoverageExt.CodeRendering
         /// <param name="e"></param>
         private void Instance_OnShowCodeCoveragePropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
+            this.outputWindow.WriteDebugLine("Instance_OnShowCodeCoveragePropertyChanged");
             Redraw();
         }
 
@@ -110,6 +113,7 @@ namespace NubiloSoft.CoverageExt.CodeRendering
         /// <param name="e"></param>
         private void Instance_OnColorPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
+            this.outputWindow.WriteDebugLine("Instance_OnColorPropertyChanged");
             InitializeColors();
             Redraw();
         }

--- a/CoverageExt/CoverageExecution.cs
+++ b/CoverageExt/CoverageExecution.cs
@@ -218,9 +218,7 @@ namespace NubiloSoft.CoverageExt
                     }
 
                     string arguments = PrepareArguments(solutionFolder, platform, Path.Combine(dllFolder, dllFilename), workingDirectory, commandline, tempFile);
-#if DEBUG
-                    this.output.WriteLine("Execute coverage: {0}", arguments);
-#endif
+                    this.output.WriteDebugLine("Execute coverage: {0}", arguments);
 
                     process.StartInfo.WorkingDirectory = dllFolder;
                     process.StartInfo.Arguments = arguments;
@@ -296,9 +294,7 @@ namespace NubiloSoft.CoverageExt
                     }
 
                     string arguments = PrepareArguments(solutionFolder, platform, Path.Combine(dllFolder, dllFilename), workingDirectory, commandline, tempFile);
-#if DEBUG
-                    this.output.WriteLine("Execute coverage: {0}", arguments);
-#endif
+                    this.output.WriteDebugLine("Execute coverage: {0}", arguments);
 
                     process.StartInfo.WorkingDirectory = Path.GetDirectoryName(tempFile);
                     process.StartInfo.Arguments = arguments;

--- a/CoverageExt/CoverageExtPackage.cs
+++ b/CoverageExt/CoverageExtPackage.cs
@@ -300,7 +300,7 @@ namespace NubiloSoft.CoverageExt
             OleMenuCommand menuCommand = sender as OleMenuCommand;
             if (menuCommand != null)
             {
-                Settings.Instance.ShowCodeCoverage = !Settings.Instance.ShowCodeCoverage;
+                Settings.Instance.ToggleShowCodeCoverage();
                 menuCommand.Checked = Settings.Instance.ShowCodeCoverage;
             }
         }

--- a/CoverageExt/GeneralOptionPageGrid.cs
+++ b/CoverageExt/GeneralOptionPageGrid.cs
@@ -84,6 +84,7 @@ namespace NubiloSoft.CoverageExt
             Settings.Instance.UncoveredPenColor = convert(UncoveredPen);
             Settings.Instance.CoveredBrushColor = convert(CoveredBrush);
             Settings.Instance.CoveredPenColor = convert(CoveredPen);
+            Settings.Instance.TriggerSettingsChanged();
         }
     }
 }

--- a/CoverageExt/OutputWindow.cs
+++ b/CoverageExt/OutputWindow.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using EnvDTE;
+﻿using EnvDTE;
 using EnvDTE80;
 
 namespace NubiloSoft.CoverageExt
@@ -66,6 +61,13 @@ namespace NubiloSoft.CoverageExt
                     window.OutputString(string.Format(format, par) + "\r\n");
                 }
             }
+        }
+
+        public void WriteDebugLine(string format, params object[] par)
+        {
+#if DEBUG
+            WriteLine(format, par);
+#endif
         }
     }
 }

--- a/CoverageExt/Settings.cs
+++ b/CoverageExt/Settings.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Runtime.CompilerServices;
 using System.Windows.Media;
 
 namespace NubiloSoft.CoverageExt
@@ -13,11 +12,13 @@ namespace NubiloSoft.CoverageExt
 
         public static Settings Instance { get => instance; }
 
-        protected bool SetField<T>(ref T field, T value, PropertyChangedEventHandler propertyChanged = null, [CallerMemberName] string propertyName = null)
+        private bool propertyChanged = true;
+
+        protected bool SetField<T>(ref T field, T value)
         {
             if (EqualityComparer<T>.Default.Equals(field, value)) return false;
             field = value;
-            propertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+            propertyChanged = true;
             return true;
         }
 
@@ -26,6 +27,23 @@ namespace NubiloSoft.CoverageExt
         public void TriggerRedraw()
         {
             RedrawNeeded();
+        }
+
+        public event EventHandler OnSettingsChanged;
+        public void TriggerSettingsChanged()
+        {
+            if (propertyChanged) {
+                OnSettingsChanged?.Invoke(this, EventArgs.Empty);
+                propertyChanged = false;
+            }
+        }
+
+        public event PropertyChangedEventHandler OnShowCodeCoveragePropertyChanged;
+        public void ToggleShowCodeCoverage()
+        {
+            this.ShowCodeCoverage = !this.ShowCodeCoverage;
+            OnShowCodeCoveragePropertyChanged?.Invoke(this, new PropertyChangedEventArgs(null));
+            propertyChanged = false;
         }
         #endregion
 
@@ -37,12 +55,11 @@ namespace NubiloSoft.CoverageExt
             set => SetField(ref useNativeCoverageSupport, value);
         }
 
-        public event PropertyChangedEventHandler OnShowCodeCoveragePropertyChanged;
         private bool showCodeCoverage = false;
         public bool ShowCodeCoverage
         {
             get => this.showCodeCoverage;
-            set => SetField(ref showCodeCoverage, value, OnShowCodeCoveragePropertyChanged);
+            set => SetField(ref showCodeCoverage, value);
         }
 
         private bool compileBeforeRunning = false;
@@ -54,34 +71,32 @@ namespace NubiloSoft.CoverageExt
         #endregion
 
         #region color definitions
-        public event PropertyChangedEventHandler OnColorPropertyChanged;
-
         private Color uncoveredBrushColor;
         public Color UncoveredBrushColor
         {
             get => this.uncoveredBrushColor;
-            set => SetField(ref uncoveredBrushColor, value, OnColorPropertyChanged);
+            set => SetField(ref uncoveredBrushColor, value);
         }
 
         private Color uncoveredPenColor = Color.FromArgb(0xD0, 0xFF, 0xCF, 0xB8);
         public Color UncoveredPenColor
         {
             get => this.uncoveredPenColor;
-            set => SetField(ref uncoveredPenColor, value, OnColorPropertyChanged);
+            set => SetField(ref uncoveredPenColor, value);
         }
 
         private Color coveredBrushColor;
         public Color CoveredBrushColor
         {
             get => this.coveredBrushColor;
-            set => SetField(ref coveredBrushColor, value, OnColorPropertyChanged);
+            set => SetField(ref coveredBrushColor, value);
         }
 
         private Color coveredPenColor = Color.FromArgb(0xD0, 0xBD, 0xFC, 0xBF);
         public Color CoveredPenColor
         {
             get => this.coveredPenColor;
-            set => SetField(ref coveredPenColor, value, OnColorPropertyChanged);
+            set => SetField(ref coveredPenColor, value);
         }
         #endregion
 


### PR DESCRIPTION
In the case of changing all colors, the OnColorPropertyChanged event was triggered 4 times. This change causes the change settings event to be generated only once.

It depends on #74.