### PR TITLE
Improved retrieval of current file name from active view.

### DIFF
--- a/CoverageExt/CodeRendering/CodeCoverage.cs
+++ b/CoverageExt/CodeRendering/CodeCoverage.cs
@@ -35,15 +35,18 @@ namespace NubiloSoft.CoverageExt.CodeRendering
         private EnvDTE.DTE dte;
         private OutputWindow outputWindow;
 
+        private readonly ITextDocumentFactoryService textDocumentFactory;
+        private ITextDocument TextDocument;
         private DateTime currentReportDate;
         private CoverageState[] currentCoverage;
         private ProfileVector currentProfile;
 
-        public CodeCoverage(IWpfTextView view, EnvDTE.DTE dte)
+        public CodeCoverage(IWpfTextView view, EnvDTE.DTE dte, ITextDocumentFactoryService textDocumentFactory )
         {
             this.dte = dte;
             this.outputWindow = new OutputWindow(dte);
             this.view = view;
+            this.textDocumentFactory = textDocumentFactory;
             this.layer = view.GetAdornmentLayer("CodeCoverage");
             this.layer.Opacity = 0.4;
             currentReportDate = DateTime.MinValue;
@@ -164,7 +167,8 @@ namespace NubiloSoft.CoverageExt.CodeRendering
         {
             try
             {
-                return dte.ActiveDocument.FullName;
+                var res = this.textDocumentFactory.TryGetTextDocument(view.TextBuffer, out TextDocument);
+                return res ? TextDocument.FilePath : null;
             }
             catch
             {

--- a/CoverageExt/CodeRendering/CodeCoverageFactory.cs
+++ b/CoverageExt/CodeRendering/CodeCoverageFactory.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel.Composition;
 using EnvDTE;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Utilities;
 using DTE = EnvDTE.DTE;
@@ -30,6 +31,9 @@ namespace NubiloSoft.CoverageExt.CodeRendering
         [Import]
         public SVsServiceProvider ServiceProvider = null;
 
+        [Import]
+        public ITextDocumentFactoryService textDocumentFactory { get; set; }
+
         /// <summary>
         /// Instantiates a CodeCoverage manager when a textView is created.
         /// </summary>
@@ -39,7 +43,7 @@ namespace NubiloSoft.CoverageExt.CodeRendering
             DTE dte = (DTE)ServiceProvider.GetService(typeof(DTE));
 
             // Store this thing somewhere so our GC doesn't incidentally destroy it.
-            var cover = new CodeCoverage(textView, dte);
+            var cover = new CodeCoverage(textView, dte, textDocumentFactory);
 
             textView.Closed += (object sender, EventArgs e) => {
                 cover.Close();


### PR DESCRIPTION
Sometimes Visual Studio updates a file that is not the active view. This causes the file to be updated by data prepared for another file.

Until now, this inaccuracy did not have a major impact because the data from the report was retrieved every time.

The change is to retrieve the file name from the active view instead of the EnvDTE object.