### PR TITLE
passToCoverageMethods: fix register references for 32bit application

### DIFF
--- a/Coverage/CoverageRunner.h
+++ b/Coverage/CoverageRunner.h
@@ -658,8 +658,8 @@ struct CoverageRunner
 									auto numberBytes = threadContextInfo.Rcx;
 									auto pointer = threadContextInfo.Rdx;
 #else
-									auto numberBytes = threadContextInfo.Eax;
-									auto pointer = threadContextInfo.Ecx;
+									auto numberBytes = threadContextInfo.Ecx;
+									auto pointer = threadContextInfo.Eax;
 #endif
 
 									auto data = new char[numberBytes + 1];


### PR DESCRIPTION
In the case of debugging, a big chunk of memory was allocated, and data was read from a strange pointer.