### PR TITLE
Fixing the import of the RunAll function in the MinimumTestApp project for the x86 architecture.

### DIFF
--- a/Library/Code.cpp
+++ b/Library/Code.cpp
@@ -22,7 +22,7 @@ struct MyClass
 
 extern "C"
 {
-	__declspec(dllexport) int __stdcall RunAll()
+	__declspec(dllexport) int __cdecl RunAll()
 	{
 		MyClass::DoSomething();
 


### PR DESCRIPTION
Changing the calling convention from __stdcall to __cdecl.