### PR TITLE
Add the PassToCPPCoverage function to passToCoverageMethods only when loading the tested process or library.

### DIFF
--- a/Coverage/CoverageRunner.h
+++ b/Coverage/CoverageRunner.h
@@ -279,7 +279,7 @@ struct CoverageRunner
 					IMAGEHLP_SYMBOL img;
 #endif
 
-					if (SymGetSymFromName(proc->Handle, "PassToCPPCoverage", &img))
+					if (SymGetSymFromName(proc->Handle, "PassToCPPCoverage", &img) && (coverageContext.filename == filename))
 					{
 						auto size = ReachabilityAnalysis::FirstInstructionSize(proc->Handle, img.Address);
 


### PR DESCRIPTION
Fix #82.

I am not convinced whether this is a solution or just a cover-up for the real problem. After applying this change, the tests do not loop indefinitely. Unfortunately, there are still problems when testing the MinimumTestApp application in x86 mode, but this is not caused by an infinite loop, but by an incorrect termination of the MinimumTestApp.exe process (Exception code: 0xc0000096).