### PR TITLE
Set UTF8 code page for console.

### DIFF
--- a/Coverage/Main.cpp
+++ b/Coverage/Main.cpp
@@ -254,8 +254,25 @@ void ParseCommandLine(int argc, const char **argv)
 #endif
 }
 
+class UTF8CodePage {
+public:
+    UTF8CodePage() : oldCodePage(::GetConsoleOutputCP())
+    {
+        ::SetConsoleOutputCP(GetACP());
+    }
+    ~UTF8CodePage()
+    {
+        ::SetConsoleOutputCP(oldCodePage);
+    }
+
+private:
+  UINT oldCodePage;
+};
+
 int main(int argc, const char** argv)
 {
+    UTF8CodePage codePage;
+
 #ifdef _DEBUG
     int parsing = 0;
     std::cout << "--- Arguments --- " << std::endl;


### PR DESCRIPTION
Restore old value after ending of work.

Before:
<img width="1115" height="419" alt="before" src="https://github.com/user-attachments/assets/3afe50f6-823d-41ba-8638-f9ff040efae4" />

After:
<img width="1115" height="419" alt="after" src="https://github.com/user-attachments/assets/51ac5989-e4cb-4a12-90a1-3791e7c6a415" />
