### PR TITLE
Testing code coverage for more paths to source files.

### DIFF
--- a/Coverage/Main.cpp
+++ b/Coverage/Main.cpp
@@ -158,7 +158,7 @@ void ParseCommandLine(int argc, const char** argv)
       }
 
       std::string t(argv[i]);
-      opts.CodePath = t;
+      opts.CodePaths.push_back(t);
     }
     else if (s == "-w")
     {

--- a/Coverage/RuntimeOptions.h
+++ b/Coverage/RuntimeOptions.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <list>
 #include <string>
 
 enum class VerboseLevel
@@ -43,7 +44,7 @@ public:
 
   std::string MergedOutput;
   std::string WorkingDirectory;
-  std::string CodePath;
+  std::list<std::string> CodePaths;
   std::string Executable;
   std::string ExecutableArguments;
   std::string PackageName = "Program.exe";


### PR DESCRIPTION
Reading paths to files from the vcxproj project.

I also did unit tests for report creation, but I got stuck when generating a NativeV2 report. It calculates MD5 from the file contents, and I don't know how to work around it. I will add the unit tests as a draft in the next PR.

Resolves #83.