### PR TITLE
Fix compilation tests.

### DIFF
--- a/Coverage/FileCallbackInfo.h
+++ b/Coverage/FileCallbackInfo.h
@@ -5,6 +5,7 @@
 #include "BreakpointData.h"
 #include "RuntimeOptions.h"
 #include "CallbackInfo.h"
+#include "Util.h"
 #include "md5.h"
 #include "ProfileNode.h"
 #include "RuntimeNotifications.h"

--- a/Coverage/Test/Test.vcxproj
+++ b/Coverage/Test/Test.vcxproj
@@ -173,7 +173,6 @@
     <ClCompile Include="md5Test.cpp" />
     <ClCompile Include="nativeV2.cpp" />
     <ClCompile Include="RuntimeNotificationsTest.cpp" />
-    <ClCompile Include="writeReportTest.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include=".runsettings" />


### PR DESCRIPTION
Add the missing include file.
Remove a writeReportTest.cpp files from project. It doesn't exist.