### PR TITLE
Deglobalization RuntimeOptions

### DIFF
--- a/Coverage/CoverageRunner.h
+++ b/Coverage/CoverageRunner.h
@@ -26,10 +26,11 @@
 
 struct CoverageRunner
 {
-  CoverageRunner(const RuntimeOptions& opts) : options(opts),
+  CoverageRunner(RuntimeOptions& opts) : options(opts),
+    notifications(opts),
     debugInfoAvailable(false),
     debuggerPresentPatched(false),
-    coverageContext(opts.Executable),
+    coverageContext(opts),
     profileInfo()
   {}
 
@@ -44,7 +45,7 @@ struct CoverageRunner
       if (!std::filesystem::exists(file))
       {
 #ifndef NDEBUG
-        if (RuntimeOptions::Instance().isAtLeastLevel(VerboseLevel::Error))
+        if (RuntimeOptionsSingleton::Instance().isAtLeastLevel(VerboseLevel::Error))
         {
           std::cerr << std::format("Impossible to find file : {0}", file) << std::endl;
         }
@@ -598,7 +599,7 @@ struct CoverageRunner
           IMAGEHLP_SYMBOL img;
 #endif
 
-          if (SymGetSymFromName(proc->Handle, "PassToCPPCoverage", &img) && (coverageContext.filename == filename))
+          if (SymGetSymFromName(proc->Handle, "PassToCPPCoverage", &img) && (coverageContext.GetFilename() == filename))
           {
             auto size = ReachabilityAnalysis::FirstInstructionSize(proc->Handle, img.Address);
 

--- a/Coverage/CoverageRunner.h
+++ b/Coverage/CoverageRunner.h
@@ -339,10 +339,10 @@ struct CoverageRunner
 
     switch (options.ExportFormat)
     {
-    case RuntimeOptions::Native:     cmd += " -format native"; break;
-    case RuntimeOptions::NativeV2:   cmd += " -format nativeV2"; break;
-    case RuntimeOptions::Cobertura:  cmd += " -format cobertura"; break;
-    case RuntimeOptions::Clover:     cmd += " -format clover"; break;
+    case RuntimeOptions::ExportFormatType::Native:     cmd += " -format native"; break;
+    case RuntimeOptions::ExportFormatType::NativeV2:   cmd += " -format nativeV2"; break;
+    case RuntimeOptions::ExportFormatType::Cobertura:  cmd += " -format cobertura"; break;
+    case RuntimeOptions::ExportFormatType::Clover:     cmd += " -format clover"; break;
     }
 
     if (options.UseStaticCodeAnalysis)

--- a/Coverage/Disassembler/ReachabilityAnalysis.cpp
+++ b/Coverage/Disassembler/ReachabilityAnalysis.cpp
@@ -11,353 +11,353 @@
 
 struct Helper
 {
-	static int ByteReader(const struct reader_info *arg, uint8_t* byte, uint64_t address)
-	{
-		if (address > arg->size) { return -1; }
+  static int ByteReader(const struct reader_info* arg, uint8_t* byte, uint64_t address)
+  {
+    if (address > arg->size) { return -1; }
 
-		*byte = arg->code[address];
-		return 0;
-	}
+    *byte = arg->code[address];
+    return 0;
+  }
 
-	static int ProcessReader(const struct reader_info *arg, uint8_t* byte, uint64_t address)
-	{
-		if (address > 16) { return -1; } // oops
+  static int ProcessReader(const struct reader_info* arg, uint8_t* byte, uint64_t address)
+  {
+    if (address > 16) { return -1; } // oops
 
-		auto ptr = reinterpret_cast<HANDLE>(arg->code);
-		
-		BYTE result;
-		SIZE_T numberBytesRead;
-		if (!ReadProcessMemory(ptr, reinterpret_cast<LPVOID>(address + arg->offset), &result, 1, &numberBytesRead))
-		{
-			if (RuntimeOptions::Instance().isAtLeastLevel(VerboseLevel::Error))
-            {
-                auto err = Util::GetLastErrorAsString();
-                std::cout << "Error reading memory from target process: " << err << std::endl;
-            }
-			return -1;
-		}
+    auto ptr = reinterpret_cast<HANDLE>(arg->code);
 
-		*byte = result;
-		return 0;
-	}
+    BYTE result;
+    SIZE_T numberBytesRead;
+    if (!ReadProcessMemory(ptr, reinterpret_cast<LPVOID>(address + arg->offset), &result, 1, &numberBytesRead))
+    {
+      if (RuntimeOptions::Instance().isAtLeastLevel(VerboseLevel::Error))
+      {
+        auto err = Util::GetLastErrorAsString();
+        std::cout << "Error reading memory from target process: " << err << std::endl;
+      }
+      return -1;
+    }
 
-	static void HandleJump(InternalInstruction& instr, uint64_t address, uint8_t* state, size_t numberBytes)
-	{
-		auto immediate = instr.immediates[0];
-		auto type = instr.operands[0].type;
-		bool valid = true;
+    *byte = result;
+    return 0;
+  }
 
-		auto enc = instr.operands[0].encoding;
-		if (enc == ENCODING_IB || enc == ENCODING_IW || enc == ENCODING_ID || enc == ENCODING_IO || enc == ENCODING_Iv || enc == ENCODING_Ia)
-		{
-			switch (type)
-			{
-				case TYPE_RELv:
-				{
-					//isBranch = true;
-					//pcrel = insn->startLocation + insn->immediateOffset + insn->immediateSize;
-					switch (instr.displacementSize)
-					{
-						case 1:
-							if (immediate & 0x80)
-								immediate |= ~(0xffull);
-							break;
-						case 2:
-							if (immediate & 0x8000)
-								immediate |= ~(0xffffull);
-							break;
-						case 4:
-							if (immediate & 0x80000000)
-								immediate |= ~(0xffffffffull);
-							break;
-						case 8:
-							break;
-						default:
-							break;
-					}
-				}
-				break;
+  static void HandleJump(InternalInstruction& instr, uint64_t address, uint8_t* state, size_t numberBytes)
+  {
+    auto immediate = instr.immediates[0];
+    auto type = instr.operands[0].type;
+    bool valid = true;
 
-				case TYPE_IMM8:
-				case TYPE_IMM16:
-				case TYPE_IMM32:
-				case TYPE_IMM64:
-				case TYPE_IMMv:
-				{
-					switch (instr.operands[0].encoding)
-					{
-						case ENCODING_IB:
-							if (immediate & 0x80)
-							{
-								immediate |= ~(0xffull);
-							}
-							break;
-						case ENCODING_IW:
-							if (immediate & 0x8000)
-								immediate |= ~(0xffffull);
-							break;
-						case ENCODING_ID:
-							if (immediate & 0x80000000)
-								immediate |= ~(0xffffffffull);
-							break;
+    auto enc = instr.operands[0].encoding;
+    if (enc == ENCODING_IB || enc == ENCODING_IW || enc == ENCODING_ID || enc == ENCODING_IO || enc == ENCODING_Iv || enc == ENCODING_Ia)
+    {
+      switch (type)
+      {
+        case TYPE_RELv:
+        {
+          //isBranch = true;
+          //pcrel = insn->startLocation + insn->immediateOffset + insn->immediateSize;
+          switch (instr.displacementSize)
+          {
+            case 1:
+              if (immediate & 0x80)
+                immediate |= ~(0xffull);
+              break;
+            case 2:
+              if (immediate & 0x8000)
+                immediate |= ~(0xffffull);
+              break;
+            case 4:
+              if (immediate & 0x80000000)
+                immediate |= ~(0xffffffffull);
+              break;
+            case 8:
+              break;
+            default:
+              break;
+          }
+        }
+        break;
 
-					}
-				}
-				break;
+        case TYPE_IMM8:
+        case TYPE_IMM16:
+        case TYPE_IMM32:
+        case TYPE_IMM64:
+        case TYPE_IMMv:
+        {
+          switch (instr.operands[0].encoding)
+          {
+            case ENCODING_IB:
+              if (immediate & 0x80)
+              {
+                immediate |= ~(0xffull);
+              }
+              break;
+            case ENCODING_IW:
+              if (immediate & 0x8000)
+                immediate |= ~(0xffffull);
+              break;
+            case ENCODING_ID:
+              if (immediate & 0x80000000)
+                immediate |= ~(0xffffffffull);
+              break;
 
-				case TYPE_REL8:
-				{
-					if (immediate & 0x80)
-						immediate |= ~(0xffull);
-				}
-				break;
+          }
+        }
+        break;
 
-				case TYPE_REL32:
-				case TYPE_REL64:
-				{
-					if (immediate & 0x80000000)
-						immediate |= ~(0xffffffffull);
-				}
-				break;
-			}
+        case TYPE_REL8:
+        {
+          if (immediate & 0x80)
+            immediate |= ~(0xffull);
+        }
+        break;
 
-			// Great, we have the immediate argument. Calculate target address:
-			auto targetAddr = static_cast<int64_t>(immediate) + address;
-			if (targetAddr < numberBytes)
-			{
-				state[targetAddr] |= 1;
-			}
-		}
-		// Otherwise we cannot handle it...
-	}
+        case TYPE_REL32:
+        case TYPE_REL64:
+        {
+          if (immediate & 0x80000000)
+            immediate |= ~(0xffffffffull);
+        }
+        break;
+      }
 
-	static void HandleTerminator(InternalInstruction& instr, uint64_t address, uint8_t* state, size_t numberBytes)
-	{
-		if (address < numberBytes)
-		{
-			state[address] |= 2;
-		}
-	}
+      // Great, we have the immediate argument. Calculate target address:
+      auto targetAddr = static_cast<int64_t>(immediate) + address;
+      if (targetAddr < numberBytes)
+      {
+        state[targetAddr] |= 1;
+      }
+    }
+    // Otherwise we cannot handle it...
+  }
 
-	static void MarkReachable(uint8_t* state, size_t numberBytes)
-	{
-		auto current = 0x10; // reachable
+  static void HandleTerminator(InternalInstruction& instr, uint64_t address, uint8_t* state, size_t numberBytes)
+  {
+    if (address < numberBytes)
+    {
+      state[address] |= 2;
+    }
+  }
 
-		for (size_t i = 0; i < numberBytes; ++i)
-		{
-			switch (state[i])
-			{
-				case 0:
-					state[i] |= current;
-					break;
-				case 1: // branch target
-					current = 0x10;
-					state[i] |= 0x10;
-					break;
-				case 2: // terminator
-					state[i] |= current;
-					current = 0;
-					break;
-				case 3: // branch target | terminator
-					state[i] |= 0x10;
-					current = 0;
-					break;
-			}
-		}
-	}
+  static void MarkReachable(uint8_t* state, size_t numberBytes)
+  {
+    auto current = 0x10; // reachable
+
+    for (size_t i = 0; i < numberBytes; ++i)
+    {
+      switch (state[i])
+      {
+        case 0:
+          state[i] |= current;
+          break;
+        case 1: // branch target
+          current = 0x10;
+          state[i] |= 0x10;
+          break;
+        case 2: // terminator
+          state[i] |= current;
+          current = 0;
+          break;
+        case 3: // branch target | terminator
+          state[i] |= 0x10;
+          current = 0;
+          break;
+      }
+    }
+  }
 };
 
 ReachabilityAnalysis::ReachabilityAnalysis(HANDLE processHandle, DWORD64 methodStart, SIZE_T numberBytes) :
-	state(0),
-	methodStart(methodStart),
-	numberBytes(numberBytes)
+  state(0),
+  methodStart(methodStart),
+  numberBytes(numberBytes)
 {
-	if (numberBytes == 0) { return; }
+  if (numberBytes == 0) { return; }
 
-	auto data = new uint8_t[numberBytes];
-	SIZE_T numberBytesRead;
-	if (!ReadProcessMemory(processHandle, reinterpret_cast<LPVOID>(methodStart), data, numberBytes, &numberBytesRead))
-	{
-		if( RuntimeOptions::Instance().isAtLeastLevel(VerboseLevel::Error) )
-        {
-            auto err = Util::GetLastErrorAsString();
-            std::cout << "Error while reading symbol: " << err << std::endl;
-        }
+  auto data = new uint8_t[numberBytes];
+  SIZE_T numberBytesRead;
+  if (!ReadProcessMemory(processHandle, reinterpret_cast<LPVOID>(methodStart), data, numberBytes, &numberBytesRead))
+  {
+    if (RuntimeOptions::Instance().isAtLeastLevel(VerboseLevel::Error))
+    {
+      auto err = Util::GetLastErrorAsString();
+      std::cout << "Error while reading symbol: " << err << std::endl;
+    }
 
-		delete[] data;
-		return;
-	}
+    delete[] data;
+    return;
+  }
 
-	// Initialize the disassembler reader
-	reader_info reader;
-	reader.code = data;
-	reader.offset = 0;
-	reader.size = numberBytes;
+  // Initialize the disassembler reader
+  reader_info reader;
+  reader.code = data;
+  reader.offset = 0;
+  reader.size = numberBytes;
 
-	// Address is the start offset to read the instruction:
-	uint64_t address = 0;
-	DWORD64 baseAddress = methodStart;
+  // Address is the start offset to read the instruction:
+  uint64_t address = 0;
+  DWORD64 baseAddress = methodStart;
 
-	// Initialize state to 0
-	state = new uint8_t[numberBytes];
-	memset(state, 0, numberBytes);
+  // Initialize state to 0
+  state = new uint8_t[numberBytes];
+  memset(state, 0, numberBytes);
 
-	InternalInstruction instr;
-	memset(&instr, 0, offsetof(InternalInstruction, reader));
+  InternalInstruction instr;
+  memset(&instr, 0, offsetof(InternalInstruction, reader));
 
-	while (address < numberBytes)
-	{
+  while (address < numberBytes)
+  {
 #if _WIN64
-		auto ret = decodeInstruction(&instr, Helper::ByteReader, &reader, address, DisassemblerMode::MODE_64BIT);
+    auto ret = decodeInstruction(&instr, Helper::ByteReader, &reader, address, DisassemblerMode::MODE_64BIT);
 #else
-		auto ret = decodeInstruction(&instr, Helper::ByteReader, &reader, address, DisassemblerMode::MODE_32BIT);
+    auto ret = decodeInstruction(&instr, Helper::ByteReader, &reader, address, DisassemblerMode::MODE_32BIT);
 #endif
 
-		size_t size;
-		if (ret)
-		{
-			size = (uint16_t)(instr.readerCursor - address);
-		}
-		else
-		{
-			size = (uint16_t)instr.length;
-		}
+    size_t size;
+    if (ret)
+    {
+      size = (uint16_t) (instr.readerCursor - address);
+    }
+    else
+    {
+      size = (uint16_t) instr.length;
+    }
 
-		if (instr.operandSize > 0)
-		{
-			// Handle instructions:
-			// - If it's a branch, we basically want to know the destination address, and mark the target with a 1.
-			// - If it's a terminator (e.g. ret, unconditional branch), we want to mark the source with a 2.
-			// - If it's something else, we don't care.
+    if (instr.operandSize > 0)
+    {
+      // Handle instructions:
+      // - If it's a branch, we basically want to know the destination address, and mark the target with a 1.
+      // - If it's a terminator (e.g. ret, unconditional branch), we want to mark the source with a 2.
+      // - If it's something else, we don't care.
 
-			switch (instr.instructionID)
-			{
-				// FarJmp, SjLj omitted.
-				// j*
-				// TAILJMP
-				// Ret, iret
+      switch (instr.instructionID)
+      {
+        // FarJmp, SjLj omitted.
+        // j*
+        // TAILJMP
+        // Ret, iret
 
-				case X86_FARJMP16i:
-				case X86_FARJMP16m:
-				case X86_FARJMP32i:
-				case X86_FARJMP32m:
-				case X86_FARJMP64:
-				case X86_JMP16m:
-				case X86_JMP16r:
-				case X86_JMP32m:
-				case X86_JMP32r:
-				case X86_JMP64m:
-				case X86_JMP64r:
-					Helper::HandleJump(instr, baseAddress + address, state, numberBytes);
-					Helper::HandleTerminator(instr, baseAddress + address, state, numberBytes);
-					break;
+        case X86_FARJMP16i:
+        case X86_FARJMP16m:
+        case X86_FARJMP32i:
+        case X86_FARJMP32m:
+        case X86_FARJMP64:
+        case X86_JMP16m:
+        case X86_JMP16r:
+        case X86_JMP32m:
+        case X86_JMP32r:
+        case X86_JMP64m:
+        case X86_JMP64r:
+          Helper::HandleJump(instr, baseAddress + address, state, numberBytes);
+          Helper::HandleTerminator(instr, baseAddress + address, state, numberBytes);
+          break;
 
-				case X86_JAE_1:
-				case X86_JA_1:
-				case X86_JBE_1:
-				case X86_JB_1:
-				case X86_JE_1:
-				case X86_JGE_1:
-				case X86_JG_1:
-				case X86_JLE_1:
-				case X86_JL_1:
-				case X86_JMP_1:
-				case X86_JNE_1:
-				case X86_JNO_1:
-				case X86_JNP_1:
-				case X86_JNS_1:
-				case X86_JO_1:
-				case X86_JP_1:
-				case X86_JS_1:
-				case X86_JCXZ:
-				case X86_JRCXZ:
-				case X86_JAE_2:
-				case X86_JA_2:
-				case X86_JB_2:
-				case X86_JBE_2:
-				case X86_JE_2:
-				case X86_JGE_2:
-				case X86_JG_2:
-				case X86_JLE_2:
-				case X86_JL_2:
-				case X86_JMP_2:
-				case X86_JNE_2:
-				case X86_JNO_2:
-				case X86_JNP_2:
-				case X86_JNS_2:
-				case X86_JO_2:
-				case X86_JP_2:
-				case X86_JS_2:
-				case X86_JAE_4:
-				case X86_JA_4:
-				case X86_JBE_4:
-				case X86_JB_4:
-				case X86_JE_4:
-				case X86_JGE_4:
-				case X86_JG_4:
-				case X86_JLE_4:
-				case X86_JL_4:
-				case X86_JMP_4:
-				case X86_JNE_4:
-				case X86_JNO_4:
-				case X86_JNP_4:
-				case X86_JNS_4:
-				case X86_JO_4:
-				case X86_JP_4:
-				case X86_JS_4:
-				case X86_JECXZ_32:
-				case X86_JECXZ_64:
-					Helper::HandleJump(instr, baseAddress + address, state, numberBytes);
-					break;
+        case X86_JAE_1:
+        case X86_JA_1:
+        case X86_JBE_1:
+        case X86_JB_1:
+        case X86_JE_1:
+        case X86_JGE_1:
+        case X86_JG_1:
+        case X86_JLE_1:
+        case X86_JL_1:
+        case X86_JMP_1:
+        case X86_JNE_1:
+        case X86_JNO_1:
+        case X86_JNP_1:
+        case X86_JNS_1:
+        case X86_JO_1:
+        case X86_JP_1:
+        case X86_JS_1:
+        case X86_JCXZ:
+        case X86_JRCXZ:
+        case X86_JAE_2:
+        case X86_JA_2:
+        case X86_JB_2:
+        case X86_JBE_2:
+        case X86_JE_2:
+        case X86_JGE_2:
+        case X86_JG_2:
+        case X86_JLE_2:
+        case X86_JL_2:
+        case X86_JMP_2:
+        case X86_JNE_2:
+        case X86_JNO_2:
+        case X86_JNP_2:
+        case X86_JNS_2:
+        case X86_JO_2:
+        case X86_JP_2:
+        case X86_JS_2:
+        case X86_JAE_4:
+        case X86_JA_4:
+        case X86_JBE_4:
+        case X86_JB_4:
+        case X86_JE_4:
+        case X86_JGE_4:
+        case X86_JG_4:
+        case X86_JLE_4:
+        case X86_JL_4:
+        case X86_JMP_4:
+        case X86_JNE_4:
+        case X86_JNO_4:
+        case X86_JNP_4:
+        case X86_JNS_4:
+        case X86_JO_4:
+        case X86_JP_4:
+        case X86_JS_4:
+        case X86_JECXZ_32:
+        case X86_JECXZ_64:
+          Helper::HandleJump(instr, baseAddress + address, state, numberBytes);
+          break;
 
-				case X86_RETIL:
-				case X86_RETIQ:
-				case X86_RETIW:
-				case X86_RETL:
-				case X86_RETQ:
-				case X86_RETW:
-					Helper::HandleTerminator(instr, baseAddress + address, state, numberBytes);
-					break;
-			}
-		}
+        case X86_RETIL:
+        case X86_RETIQ:
+        case X86_RETIW:
+        case X86_RETL:
+        case X86_RETQ:
+        case X86_RETW:
+          Helper::HandleTerminator(instr, baseAddress + address, state, numberBytes);
+          break;
+      }
+    }
 
-		address += size;
-	}
+    address += size;
+  }
 
-	Helper::MarkReachable(state, numberBytes);
+  Helper::MarkReachable(state, numberBytes);
 
-	delete[] data;
+  delete[] data;
 }
 
 size_t ReachabilityAnalysis::FirstInstructionSize(HANDLE processHandle, DWORD64 methodStart)
 {
-	// Initialize the disassembler reader
-	reader_info reader;
-	reader.code = reinterpret_cast<uint8_t*>(processHandle);
-	reader.offset = methodStart;
-	reader.size = 16; // not used
+  // Initialize the disassembler reader
+  reader_info reader;
+  reader.code = reinterpret_cast<uint8_t*>(processHandle);
+  reader.offset = methodStart;
+  reader.size = 16; // not used
 
-	// Address is the start offset to read the instruction:
-	uint64_t address = 0;
+  // Address is the start offset to read the instruction:
+  uint64_t address = 0;
 
-	// Initialize state to 0
-	InternalInstruction instr;
-	memset(&instr, 0, offsetof(InternalInstruction, reader));
+  // Initialize state to 0
+  InternalInstruction instr;
+  memset(&instr, 0, offsetof(InternalInstruction, reader));
 
 #if _WIN64
-	auto ret = decodeInstruction(&instr, Helper::ProcessReader, &reader, address, DisassemblerMode::MODE_64BIT);
+  auto ret = decodeInstruction(&instr, Helper::ProcessReader, &reader, address, DisassemblerMode::MODE_64BIT);
 #else
-	auto ret = decodeInstruction(&instr, Helper::ProcessReader, &reader, address, DisassemblerMode::MODE_32BIT);
+  auto ret = decodeInstruction(&instr, Helper::ProcessReader, &reader, address, DisassemblerMode::MODE_32BIT);
 #endif
 
-	size_t size;
-	if (ret)
-	{
-		size = (uint16_t)(instr.readerCursor - address);
-	}
-	else
-	{
-		size = (uint16_t)instr.length;
-	}
-	return size;
+  size_t size;
+  if (ret)
+  {
+    size = (uint16_t) (instr.readerCursor - address);
+  }
+  else
+  {
+    size = (uint16_t) instr.length;
+  }
+  return size;
 }

--- a/Coverage/Disassembler/ReachabilityAnalysis.cpp
+++ b/Coverage/Disassembler/ReachabilityAnalysis.cpp
@@ -29,7 +29,7 @@ struct Helper
     SIZE_T numberBytesRead;
     if (!ReadProcessMemory(ptr, reinterpret_cast<LPVOID>(address + arg->offset), &result, 1, &numberBytesRead))
     {
-      if (RuntimeOptions::Instance().isAtLeastLevel(VerboseLevel::Error))
+      if (RuntimeOptionsSingleton::Instance().isAtLeastLevel(VerboseLevel::Error))
       {
         auto err = Util::GetLastErrorAsString();
         std::cout << "Error reading memory from target process: " << err << std::endl;
@@ -178,7 +178,7 @@ ReachabilityAnalysis::ReachabilityAnalysis(HANDLE processHandle, DWORD64 methodS
   SIZE_T numberBytesRead;
   if (!ReadProcessMemory(processHandle, reinterpret_cast<LPVOID>(methodStart), data, numberBytes, &numberBytesRead))
   {
-    if (RuntimeOptions::Instance().isAtLeastLevel(VerboseLevel::Error))
+    if (RuntimeOptionsSingleton::Instance().isAtLeastLevel(VerboseLevel::Error))
     {
       auto err = Util::GetLastErrorAsString();
       std::cout << "Error while reading symbol: " << err << std::endl;

--- a/Coverage/Disassembler/ReachabilityAnalysis.h
+++ b/Coverage/Disassembler/ReachabilityAnalysis.h
@@ -7,60 +7,60 @@
 
 struct ReachabilityAnalysis
 {
-	ReachabilityAnalysis(const ReachabilityAnalysis&) = delete;
-	ReachabilityAnalysis& operator=(const ReachabilityAnalysis&) = delete;
+  ReachabilityAnalysis(const ReachabilityAnalysis&) = delete;
+  ReachabilityAnalysis& operator=(const ReachabilityAnalysis&) = delete;
 
-	ReachabilityAnalysis(ReachabilityAnalysis&& o) noexcept
-	{
-		state = 0;
-		methodStart = 0;
-		numberBytes = 0;
+  ReachabilityAnalysis(ReachabilityAnalysis&& o) noexcept
+  {
+    state = 0;
+    methodStart = 0;
+    numberBytes = 0;
 
-		std::swap(state, o.state);
-		std::swap(methodStart, o.methodStart);
-		std::swap(numberBytes, o.numberBytes);
-	}
+    std::swap(state, o.state);
+    std::swap(methodStart, o.methodStart);
+    std::swap(numberBytes, o.numberBytes);
+  }
 
-	ReachabilityAnalysis& operator=(ReachabilityAnalysis&& o) noexcept
-	{
-		if (this != &o)
-		{
-			delete state;
+  ReachabilityAnalysis& operator=(ReachabilityAnalysis&& o) noexcept
+  {
+    if (this != &o)
+    {
+      delete state;
 
-			state = 0;
-			methodStart = 0;
-			numberBytes = 0;
+      state = 0;
+      methodStart = 0;
+      numberBytes = 0;
 
-			std::swap(state, o.state);
-			std::swap(methodStart, o.methodStart);
-			std::swap(numberBytes, o.numberBytes);
-		}
-		return *this;
-	}
+      std::swap(state, o.state);
+      std::swap(methodStart, o.methodStart);
+      std::swap(numberBytes, o.numberBytes);
+    }
+    return *this;
+  }
 
-	ReachabilityAnalysis(HANDLE processHandle, DWORD64 methodStart, SIZE_T numberBytes);
+  ReachabilityAnalysis(HANDLE processHandle, DWORD64 methodStart, SIZE_T numberBytes);
 
-	static size_t FirstInstructionSize(HANDLE processHandle, DWORD64 methodStart);
+  static size_t FirstInstructionSize(HANDLE processHandle, DWORD64 methodStart);
 
-	DWORD64 methodStart;
-	size_t numberBytes;
-	uint8_t* state;
+  DWORD64 methodStart;
+  size_t numberBytes;
+  uint8_t* state;
 
-	bool operator<(const ReachabilityAnalysis& o) const
-	{
-		return methodStart < o.methodStart;
-	}
+  bool operator<(const ReachabilityAnalysis& o) const
+  {
+    return methodStart < o.methodStart;
+  }
 
-	friend void swap(ReachabilityAnalysis& lhs, ReachabilityAnalysis& rhs)
-	{
-		std::swap(lhs.state, rhs.state);
-		std::swap(lhs.methodStart, rhs.methodStart);
-		std::swap(lhs.numberBytes, rhs.numberBytes);
-	}
+  friend void swap(ReachabilityAnalysis& lhs, ReachabilityAnalysis& rhs)
+  {
+    std::swap(lhs.state, rhs.state);
+    std::swap(lhs.methodStart, rhs.methodStart);
+    std::swap(lhs.numberBytes, rhs.numberBytes);
+  }
 
-	~ReachabilityAnalysis()
-	{
-		delete[] state;
-		state = 0;
-	}
+  ~ReachabilityAnalysis()
+  {
+    delete[] state;
+    state = 0;
+  }
 };

--- a/Coverage/FileCallbackInfo.h
+++ b/Coverage/FileCallbackInfo.h
@@ -128,9 +128,9 @@ struct FileCallbackInfo
   {
     switch (exportFormat)
     {
-      case RuntimeOptions::Clover:    WriteClover(stream); break;
-      case RuntimeOptions::Cobertura: WriteCobertura(stream); break;
-      case RuntimeOptions::NativeV2:  WriteNativeV2(stream); break;
+      case RuntimeOptions::ExportFormatType::Clover:    WriteClover(stream); break;
+      case RuntimeOptions::ExportFormatType::Cobertura: WriteCobertura(stream); break;
+      case RuntimeOptions::ExportFormatType::NativeV2:  WriteNativeV2(stream); break;
       default: WriteNative(stream, mergedProfileInfo); break;
     }
   }

--- a/Coverage/FileCallbackInfo.h
+++ b/Coverage/FileCallbackInfo.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "FileLineInfo.h"
+#include "FileInfo.h"
 #include "FileCoverageV2.h"
 #include "BreakpointData.h"
 #include "RuntimeOptions.h"
@@ -21,11 +21,12 @@
 
 struct FileCallbackInfo
 {
-  FileCallbackInfo(const std::string& filename) :
-    filename(filename)
+  FileCallbackInfo(const RuntimeOptions& opts) :
+    opts(opts)
   {
-    if (RuntimeOptions::Instance().CodePaths.empty())
+    if (opts.CodePaths.empty())
     {
+      const auto& filename = opts.Executable;
       auto idx = filename.find("x64");
       if (idx == std::string::npos)
       {
@@ -47,13 +48,17 @@ struct FileCallbackInfo
     }
   }
 
-  std::string filename;
   std::string sourcePath;
 
   using MergedProfileInfoMap = std::unordered_map<std::string, std::unique_ptr<std::vector<ProfileInfo>>>;
   using FileInfoMap = std::unordered_map<std::string, std::unique_ptr<FileInfo>>;
 
   FileInfoMap lineData;
+
+  const std::string& GetFilename()
+  {
+    return opts.Executable;
+  }
 
   void Filter(RuntimeNotifications& notifications)
   {
@@ -66,7 +71,7 @@ struct FileCallbackInfo
         std::swap(tmp, it.second);
         newLineData[it.first] = std::move(tmp);
       }
-      else if (RuntimeOptions::Instance().isAtLeastLevel(VerboseLevel::Trace))
+      else if (opts.isAtLeastLevel(VerboseLevel::Trace))
       {
         std::cout << "Removing file " << it.first << std::endl;
       }
@@ -97,7 +102,7 @@ struct FileCallbackInfo
       return PathMatches(filename, sourcePath);
     }
 
-    const auto& codePaths = RuntimeOptions::Instance().CodePaths;
+    const auto& codePaths = opts.CodePaths;
     for (const auto& codePath : codePaths)
     {
       if (PathMatches(filename, codePath))
@@ -136,6 +141,7 @@ struct FileCallbackInfo
   }
 
 private:
+  const RuntimeOptions& opts;
 
   void WriteClover(std::ostream& stream)
   {
@@ -170,7 +176,7 @@ private:
     // stream << "coveredstatements=\"300\" statements=\"500\" coveredmethods=\"50\" methods=\"80\" ";
     // stream << "coveredconditionals=\"100\" conditionals=\"120\" coveredelements=\"900\" elements=\"1000\" ";
     stream << "complexity=\"0\" />" << std::endl;
-    stream << "<package name=\"" << RuntimeOptions::Instance().PackageName << "\">" << std::endl;
+    stream << "<package name=\"" << opts.PackageName << "\">" << std::endl;
     for (auto& it : lineData)
     {
       auto ptr = it.second.get();
@@ -229,7 +235,7 @@ private:
     stream << "<coverage line-rate=\"" << lineRate << "\"" << " " << "version=\"\">" << std::endl;
     stream << "\t" << "<packages>" << std::endl;
 
-    stream << "\t\t" << "<package name=\"" << RuntimeOptions::Instance().PackageName << "\" line-rate=\"" << lineRate << "\">" << std::endl;
+    stream << "\t\t" << "<package name=\"" << opts.PackageName << "\" line-rate=\"" << lineRate << "\">" << std::endl;
     stream << "\t\t\t" << "<classes>" << std::endl;
     for (auto& it : lineData)
     {
@@ -379,7 +385,7 @@ private:
       filepaths.push_back(item.first);
     }
 
-    for (const auto& dirPath : RuntimeOptions::Instance().CodePaths)
+    for (const auto& dirPath : opts.CodePaths)
     {
       bool dirPartAdded = false;
 
@@ -417,7 +423,7 @@ private:
       }
     }
 
-    if (!filepaths.empty() && RuntimeOptions::Instance().isAtLeastLevel(VerboseLevel::Warning))
+    if (!filepaths.empty() && opts.isAtLeastLevel(VerboseLevel::Warning))
     {
       std::cerr << "List of refuse coverage files (because not relative to any code path):" << std::endl;
 
@@ -428,7 +434,7 @@ private:
 
       std::cerr << std::endl << "List of code paths:" << std::endl;
 
-      for (const auto& dirPath : RuntimeOptions::Instance().CodePaths)
+      for (const auto& dirPath : opts.CodePaths)
       {
         std::cerr << std::format("- {0}", dirPath) << std::endl;
       }

--- a/Coverage/FileCoverageV2.h
+++ b/Coverage/FileCoverageV2.h
@@ -1,10 +1,11 @@
 #pragma once
 
 #include "base64.h"
-#include "FileInfo.h"
+#include "FileLineInfo.h"
 
 #include <format>
 #include <fstream>
+#include <vector>
 
 struct FileCoverageV2
 {

--- a/Coverage/FileCoverageV2.h
+++ b/Coverage/FileCoverageV2.h
@@ -3,6 +3,7 @@
 #include "base64.h"
 #include "FileLineInfo.h"
 
+#include <filesystem>
 #include <format>
 #include <fstream>
 #include <vector>
@@ -98,9 +99,9 @@ struct FileCoverageV2
     ofs << std::format(R"(<CppCoverage version="{0}">)", version) << std::endl;
   }
 
-  static void openDirectory(std::ostream& ofs, const std::string& aDir)
+  static void openDirectory(std::ostream& ofs, const std::filesystem::path& aDir)
   {
-    ofs << std::format(R"(	<directory path="{0}">)", aDir) << std::endl;
+    ofs << std::format(R"(	<directory path="{0}">)", aDir.string()) << std::endl;
   }
 
   static void closeDirectory(std::ostream& ofs)

--- a/Coverage/FileInfo.cpp
+++ b/Coverage/FileInfo.cpp
@@ -111,7 +111,7 @@ FileLineInfo* FileInfo::LineInfo(size_t lineNumber)
     if (lineNumber < 0xf00000 - 1 &&
         lineNumber != numberLines)
     {
-      if (RuntimeOptions::Instance().isAtLeastLevel(VerboseLevel::Warning))
+      if (RuntimeOptionsSingleton::Instance().isAtLeastLevel(VerboseLevel::Warning))
       {
         std::cout << "Warning: line number out of bounds: " << lineNumber << " >= " << numberLines << std::endl;
       }

--- a/Coverage/Main.cpp
+++ b/Coverage/Main.cpp
@@ -158,19 +158,19 @@ void ParseCommandLine(int argc, const char** argv)
       std::string t(argv[i]);
       if (t == "native")
       {
-        opts.ExportFormat = RuntimeOptions::Native;
+        opts.ExportFormat = RuntimeOptions::ExportFormatType::Native;
       }
       else if (t == "nativeV2")
       {
-        opts.ExportFormat = RuntimeOptions::NativeV2;
+        opts.ExportFormat = RuntimeOptions::ExportFormatType::NativeV2;
       }
       else if (t == "cobertura")
       {
-        opts.ExportFormat = RuntimeOptions::Cobertura;
+        opts.ExportFormat = RuntimeOptions::ExportFormatType::Cobertura;
       }
       else if (t == "clover")
       {
-        opts.ExportFormat = RuntimeOptions::Clover;
+        opts.ExportFormat = RuntimeOptions::ExportFormatType::Clover;
       }
       else
       {
@@ -257,14 +257,18 @@ void ParseCommandLine(int argc, const char** argv)
   }
 
   // Check we can merge
-  if ((opts.ExportFormat != RuntimeOptions::Native && opts.ExportFormat != RuntimeOptions::NativeV2) && !opts.MergedOutput.empty())
+  if (opts.ExportFormat != RuntimeOptions::ExportFormatType::Native &&
+      opts.ExportFormat != RuntimeOptions::ExportFormatType::NativeV2 &&
+      !opts.MergedOutput.empty())
   {
     throw std::exception("Merge mode is only for RuntimeOptions::Native or NativeV2 mode.");
   }
 
   // -consolidate piggy-backs on the Native / NativeV2 merge machinery, so
   // reject it for formats that can't round-trip through MergeRunner.
-  if ((opts.ExportFormat != RuntimeOptions::Native && opts.ExportFormat != RuntimeOptions::NativeV2) && opts.ConsolidateAuxiliary)
+  if (opts.ExportFormat != RuntimeOptions::ExportFormatType::Native &&
+      opts.ExportFormat != RuntimeOptions::ExportFormatType::NativeV2 &&
+      opts.ConsolidateAuxiliary)
   {
     throw std::exception("-consolidate is only supported for -format native or nativeV2.");
   }

--- a/Coverage/Main.cpp
+++ b/Coverage/Main.cpp
@@ -328,7 +328,7 @@ void ParseCommandLine(int argc, const char** argv)
       opts.ExecutableArguments = opts.ExecutableArguments.substr(1);
   */
 #ifdef _DEBUG
-  if (RuntimeOptions::Instance().isAtLeastLevel(VerboseLevel::Trace))
+  if (opts.isAtLeastLevel(VerboseLevel::Trace))
   {
     std::cout << "Executable: " << opts.Executable << std::endl;
     std::cout << "Arguments: " << opts.ExecutableArguments << std::endl;
@@ -373,7 +373,7 @@ int main(int argc, const char** argv)
   }
   catch (const std::exception& e)
   {
-    if (RuntimeOptions::Instance().isAtLeastLevel(VerboseLevel::Error))
+    if (opts.isAtLeastLevel(VerboseLevel::Error))
     {
       std::cerr << "Error: " << e.what() << std::endl;
     }
@@ -392,7 +392,7 @@ int main(int argc, const char** argv)
   {
     if (opts.Executable.empty())
     {
-      if (RuntimeOptions::Instance().isAtLeastLevel(VerboseLevel::Error))
+      if (opts.isAtLeastLevel(VerboseLevel::Error))
       {
         std::cerr << "Error: Missing executable file" << std::endl;
       }
@@ -442,7 +442,7 @@ int main(int argc, const char** argv)
     {
       if (!std::filesystem::exists(localOutputFile))
       {
-        if (RuntimeOptions::Instance().isAtLeastLevel(VerboseLevel::Warning))
+        if (opts.isAtLeastLevel(VerboseLevel::Warning))
         {
           std::cerr << "Warning: -consolidate requested but the master coverage file is missing: "
             << localOutputFile << std::endl;
@@ -454,14 +454,14 @@ int main(int argc, const char** argv)
         {
           if (!std::filesystem::exists(auxFile))
           {
-            if (RuntimeOptions::Instance().isAtLeastLevel(VerboseLevel::Warning))
+            if (opts.isAtLeastLevel(VerboseLevel::Warning))
             {
               std::cerr << "Warning: expected auxiliary coverage file missing: " << auxFile << std::endl;
             }
             continue;
           }
 
-          if (RuntimeOptions::Instance().isAtLeastLevel(VerboseLevel::Info))
+          if (opts.isAtLeastLevel(VerboseLevel::Info))
           {
             std::cout << "Consolidating auxiliary coverage into "
               << localOutputFile << ": " << auxFile << std::endl;
@@ -477,7 +477,7 @@ int main(int argc, const char** argv)
 
           std::error_code ec;
           std::filesystem::remove(auxFile, ec);
-          if (ec && RuntimeOptions::Instance().isAtLeastLevel(VerboseLevel::Warning))
+          if (ec && opts.isAtLeastLevel(VerboseLevel::Warning))
           {
             std::cerr << "Warning: failed to remove consolidated aux file "
               << auxFile << ": " << ec.message() << std::endl;
@@ -492,7 +492,7 @@ int main(int argc, const char** argv)
   }
   catch (const std::exception& e)
   {
-    if (RuntimeOptions::Instance().isAtLeastLevel(VerboseLevel::Error))
+    if (opts.isAtLeastLevel(VerboseLevel::Error))
     {
       std::cerr << "Error while consolidating auxiliary coverage: " << e.what() << std::endl;
     }
@@ -504,7 +504,7 @@ int main(int argc, const char** argv)
   {
     if (!opts.MergedOutput.empty())
     {
-      if (RuntimeOptions::Instance().isAtLeastLevel(VerboseLevel::Info))
+      if (opts.isAtLeastLevel(VerboseLevel::Info))
       {
         std::cout << "Merge into " << opts.MergedOutput << std::endl;
       }
@@ -522,7 +522,7 @@ int main(int argc, const char** argv)
       {
         if (!std::filesystem::exists(auxFile))
         {
-          if (RuntimeOptions::Instance().isAtLeastLevel(VerboseLevel::Warning))
+          if (opts.isAtLeastLevel(VerboseLevel::Warning))
           {
             std::cerr << "Warning: expected auxiliary coverage file missing: " << auxFile << std::endl;
           }
@@ -531,7 +531,7 @@ int main(int argc, const char** argv)
 
         RuntimeOptions auxOpts = opts;
         auxOpts.OutputFile = auxFile;
-        if (RuntimeOptions::Instance().isAtLeastLevel(VerboseLevel::Info))
+        if (opts.isAtLeastLevel(VerboseLevel::Info))
         {
           std::cout << "Merging auxiliary coverage: " << auxFile << std::endl;
         }
@@ -542,7 +542,7 @@ int main(int argc, const char** argv)
   }
   catch (const std::exception& e)
   {
-    if (RuntimeOptions::Instance().isAtLeastLevel(VerboseLevel::Error))
+    if (opts.isAtLeastLevel(VerboseLevel::Error))
     {
       std::cerr << "Error: " << e.what() << std::endl;
     }

--- a/Coverage/Main.cpp
+++ b/Coverage/Main.cpp
@@ -195,7 +195,7 @@ void ParseCommandLine(int argc, const char** argv, RuntimeOptions& opts)
       }
 
       std::string t(argv[i]);
-      opts.CodePaths.push_back(t);
+      opts.CodePaths.emplace(t);
     }
     else if (s == "-w")
     {

--- a/Coverage/Main.cpp
+++ b/Coverage/Main.cpp
@@ -53,10 +53,8 @@ void ShowHelp()
   std::cout << std::endl;
 }
 
-void ParseCommandLine(int argc, const char** argv)
+void ParseCommandLine(int argc, const char** argv, RuntimeOptions& opts)
 {
-  RuntimeOptions& opts = RuntimeOptions::Instance();
-
   LPTSTR cmd = GetCommandLine();
   std::string cmdLine = cmd;
 
@@ -365,11 +363,11 @@ int main(int argc, const char** argv)
   }
 #endif
 
-  RuntimeOptions& opts = RuntimeOptions::Instance();
+  auto& opts = RuntimeOptionsSingleton::Instance();
 
   try
   {
-    ParseCommandLine(argc, argv);
+    ParseCommandLine(argc, argv, opts);
   }
   catch (const std::exception& e)
   {

--- a/Coverage/MergeRunner.cpp
+++ b/Coverage/MergeRunner.cpp
@@ -11,10 +11,10 @@ MergeRunner::MergeRunner(const RuntimeOptions& opts) :
 
   switch (opts.ExportFormat)
   {
-    case RuntimeOptions::Native:
+    case RuntimeOptions::ExportFormatType::Native:
       runner = std::make_unique<MergeRunnerV1>();
       break;
-    case RuntimeOptions::NativeV2:
+    case RuntimeOptions::ExportFormatType::NativeV2:
       runner = std::make_unique<MergeRunnerV2>();
       break;
     default:

--- a/Coverage/RuntimeNotifications.cpp
+++ b/Coverage/RuntimeNotifications.cpp
@@ -49,6 +49,10 @@ struct RuntimeFolderFilter : RuntimeCoverageFilter
 };
 
 
+RuntimeNotifications::RuntimeNotifications(RuntimeOptions& options) :
+  opts(options)
+{}
+
 std::string RuntimeNotifications::Trim(const std::string& t)
 {
   std::string s = t;
@@ -73,7 +77,7 @@ std::string RuntimeNotifications::GetFQN(std::string s)
   static constexpr char BACKSLASH = '\\';
   static constexpr std::string_view parentDir = "..\\";
 
-  auto cp = RuntimeOptions::Instance().SolutionPath;
+  auto cp = opts.SolutionPath;
   if (cp.empty()) { return s; }
 
   while (s.size() > parentDir.size() && s.starts_with(parentDir))
@@ -112,7 +116,7 @@ std::string RuntimeNotifications::GetFQN(std::string s)
 
 void RuntimeNotifications::PrintInvalidNotification(const std::string& notification, const std::string_view information)
 {
-  if (RuntimeOptions::Instance().isAtLeastLevel(VerboseLevel::Warning))
+  if (opts.isAtLeastLevel(VerboseLevel::Warning))
   {
     std::cout << "WARNING: Invalid path " << notification << ". " << information << std::endl;
   }
@@ -144,7 +148,7 @@ void RuntimeNotifications::Handle(const char* data, const size_t size)
     }
     else
     {
-      if (RuntimeOptions::Instance().isAtLeastLevel(VerboseLevel::Info))
+      if (opts.isAtLeastLevel(VerboseLevel::Info))
       {
         std::cout << "Ignoring folder: " << fullname << std::endl;
       }
@@ -166,7 +170,7 @@ void RuntimeNotifications::Handle(const char* data, const size_t size)
     }
     else
     {
-      if (RuntimeOptions::Instance().isAtLeastLevel(VerboseLevel::Info))
+      if (opts.isAtLeastLevel(VerboseLevel::Info))
       {
         std::cout << "Ignoring file: " << file << std::endl;
       }
@@ -175,13 +179,13 @@ void RuntimeNotifications::Handle(const char* data, const size_t size)
   }
   else if (s == "ENABLE CODE ANALYSIS")
   {
-    RuntimeOptions::Instance().UseStaticCodeAnalysis = true;
+    opts.UseStaticCodeAnalysis = true;
   }
   else if (s == "DISABLE CODE ANALYSIS")
   {
-    RuntimeOptions::Instance().UseStaticCodeAnalysis = false;
+    opts.UseStaticCodeAnalysis = false;
   }
-  else if (RuntimeOptions::Instance().isAtLeastLevel(VerboseLevel::Error))
+  else if (opts.isAtLeastLevel(VerboseLevel::Error))
   {
     std::cout << "Unknown option passed to coverage: " << s << std::endl;
   }

--- a/Coverage/RuntimeNotifications.h
+++ b/Coverage/RuntimeNotifications.h
@@ -9,13 +9,17 @@ struct RuntimeCoverageFilter
   virtual bool IgnoreFile(const std::string& file) const = 0;
 };
 
+struct RuntimeOptions;
+
 struct RuntimeNotifications
 {
 public:
+  explicit RuntimeNotifications(RuntimeOptions& options);
   void Handle(const char* data, const size_t size);
   bool IgnoreFile(const std::string& filename) const;
 private:
   std::vector<std::unique_ptr<RuntimeCoverageFilter>> postProcessing;
+  RuntimeOptions& opts;
 
   std::string Trim(const std::string& t);
   std::string GetFQN(std::string s);

--- a/Coverage/RuntimeOptions.h
+++ b/Coverage/RuntimeOptions.h
@@ -16,16 +16,8 @@ enum class VerboseLevel
 
 struct RuntimeOptions
 {
-private:
-  RuntimeOptions() :
-  {}
-
-public:
-  static RuntimeOptions& Instance()
-  {
-    static RuntimeOptions instance;
-    return instance;
-  }
+  explicit RuntimeOptions() = default;
+  virtual ~RuntimeOptions() = default;
 
   VerboseLevel _verboseLevel = VerboseLevel::Trace;
 
@@ -68,4 +60,19 @@ public:
   bool ConsolidateAuxiliary = false;
 
   bool isAtLeastLevel(const VerboseLevel& level) const { return (static_cast<int>(_verboseLevel) & static_cast<int>(level)) == static_cast<int>(level); }
+};
+
+struct RuntimeOptionsSingleton : public RuntimeOptions
+{
+private:
+  RuntimeOptionsSingleton() = default;
+
+public:
+  ~RuntimeOptionsSingleton() override = default;
+
+  static RuntimeOptions& Instance()
+  {
+    static RuntimeOptionsSingleton instance;
+    return instance;
+  }
 };

--- a/Coverage/RuntimeOptions.h
+++ b/Coverage/RuntimeOptions.h
@@ -18,11 +18,6 @@ struct RuntimeOptions
 {
 private:
   RuntimeOptions() :
-    UseStaticCodeAnalysis(false),
-    ExportFormat(Native),
-    Attach(false),
-    AttachPid(0),
-    ConsolidateAuxiliary(false)
   {}
 
 public:
@@ -34,15 +29,15 @@ public:
 
   VerboseLevel _verboseLevel = VerboseLevel::Trace;
 
-  bool UseStaticCodeAnalysis;
+  bool UseStaticCodeAnalysis = false;
 
-  enum ExportFormatType
+  enum class ExportFormatType
   {
     Native,
     NativeV2,
     Cobertura,
     Clover
-  } ExportFormat = Native;
+  } ExportFormat = ExportFormatType::Native;
 
 
   std::string OutputFile;
@@ -62,15 +57,15 @@ public:
   // vstest.console.exe (x64) spawning testhost.x86.exe (x86)); the parent
   // Coverage-x64.exe then launches Coverage-x86.exe with -attach <pid> to
   // instrument the x86 child.
-  bool Attach;
-  DWORD AttachPid;
+  bool Attach = false;
+  DWORD AttachPid = 0;
 
   // When true, after the coverage run finishes and any sibling-bitness
   // CPPCoverage helper processes have produced their own .cov files, the
   // master process merges those files into its own -o output file and
   // deletes them. Only supported for Native / NativeV2 export formats
   // (the same restriction that applies to -m / MergedOutput).
-  bool ConsolidateAuxiliary;
+  bool ConsolidateAuxiliary = false;
 
   bool isAtLeastLevel(const VerboseLevel& level) const { return (static_cast<int>(_verboseLevel) & static_cast<int>(level)) == static_cast<int>(level); }
 };

--- a/Coverage/RuntimeOptions.h
+++ b/Coverage/RuntimeOptions.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <list>
 #include <string>
+#include <unordered_set>
 
 #include <Windows.h>
 
@@ -36,7 +36,7 @@ struct RuntimeOptions
 
   std::string MergedOutput;
   std::string WorkingDirectory;
-  std::list<std::string> CodePaths;
+  std::unordered_set<std::string> CodePaths;
   std::string Executable;
   std::string ExecutableArguments;
   std::string PackageName = "Program.exe";

--- a/Coverage/Test/FileCallbackInfoTest.cpp
+++ b/Coverage/Test/FileCallbackInfoTest.cpp
@@ -34,7 +34,7 @@ namespace TestFileCallbackInfo
 				"PROF: \n";
 
 			RuntimeOptions options;
-			options.CodePaths.push_back("C:\\proj\\src\\");
+			options.CodePaths.emplace("C:\\proj\\src\\");
 			options.Executable = "report.txt";
 
 			FileCallbackInfo fileCallbackInfo(options);
@@ -93,9 +93,9 @@ namespace TestFileCallbackInfo
 	public:
 		TestWriteReport()
 		{
-			options.CodePaths.push_back("C:\\proj\\src\\");
-			options.CodePaths.push_back("C:\\proj\\empty\\");
-			options.CodePaths.push_back("C:\\proj\\lib\\");
+			options.CodePaths.emplace("C:\\proj\\src\\");
+			options.CodePaths.emplace("C:\\proj\\empty\\");
+			options.CodePaths.emplace("C:\\proj\\lib\\");
 
 			options.Executable = "report.txt";
 			options.PackageName = "MyPackage.exe";

--- a/Coverage/Test/FileCallbackInfoTest.cpp
+++ b/Coverage/Test/FileCallbackInfoTest.cpp
@@ -13,9 +13,6 @@ namespace TestFileCallbackInfo
 	public:
 		TestLineInfo()
 		{
-			auto& options = RuntimeOptions::Instance();
-			options.CodePaths.push_back("C:\\proj\\src\\");
-
 			// create a test file
 			FileSystem::CreateTestFile("C:\\proj\\src\\srcFile.cpp", "Line_1\nLine_2\nLine_3\nLine_4");
 			FileSystem::CreateTestFile("C:\\proj\\src\\srcFile.hpp", "Line_1\nLine_2\n");
@@ -23,9 +20,6 @@ namespace TestFileCallbackInfo
 
 		~TestLineInfo()
 		{
-			auto& options = RuntimeOptions::Instance();
-			options.CodePaths.clear();
-
 			FileSystem::DeleteTestFiles();
 		}
 
@@ -39,7 +33,11 @@ namespace TestFileCallbackInfo
 				"RES: u_\n" \
 				"PROF: \n";
 
-			FileCallbackInfo fileCallbackInfo("report.txt");
+			RuntimeOptions options;
+			options.CodePaths.push_back("C:\\proj\\src\\");
+			options.Executable = "report.txt";
+
+			FileCallbackInfo fileCallbackInfo(options);
 			auto ptr = fileCallbackInfo.LineInfo("C:\\proj\\src\\srcFile.cpp", 1);
 			Assert::IsNotNull(ptr);
 			ptr->DebugCount = 1;
@@ -71,6 +69,7 @@ namespace TestFileCallbackInfo
 
 	TEST_CLASS(TestWriteReport)
 	{
+		RuntimeOptions options;
 		FileCallbackInfo* fileCallbackInfo = nullptr;
 
 		std::vector<FileLineInfo> createFileLineInfoArray(const std::vector<std::tuple<uint16_t, uint16_t>>& lineInfo)
@@ -94,11 +93,11 @@ namespace TestFileCallbackInfo
 	public:
 		TestWriteReport()
 		{
-			auto& options = RuntimeOptions::Instance();
 			options.CodePaths.push_back("C:\\proj\\src\\");
 			options.CodePaths.push_back("C:\\proj\\empty\\");
 			options.CodePaths.push_back("C:\\proj\\lib\\");
 
+			options.Executable = "report.txt";
 			options.PackageName = "MyPackage.exe";
 
 			// create test files
@@ -108,7 +107,7 @@ namespace TestFileCallbackInfo
 			FileSystem::CreateTestFile("C:\\proj\\lib\\libFile.h", "1st line\n2nd line\n3rd line");
 
 			// create instance of FileCallbackInfo
-			fileCallbackInfo = new FileCallbackInfo("report.txt");
+			fileCallbackInfo = new FileCallbackInfo(options);
 			Assert::IsNotNull(fileCallbackInfo);
 
 			// add informations about test files
@@ -120,10 +119,6 @@ namespace TestFileCallbackInfo
 
 		~TestWriteReport()
 		{
-			auto& options = RuntimeOptions::Instance();
-			options.CodePaths.clear();
-			options.PackageName.clear();
-
 			FileSystem::DeleteTestFiles();
 
 			delete fileCallbackInfo;

--- a/Coverage/Test/RuntimeNotificationsTest.cpp
+++ b/Coverage/Test/RuntimeNotificationsTest.cpp
@@ -11,6 +11,10 @@ namespace TestRuntimeNotifications
 {
 	TEST_CLASS(TestNotifications)
 	{
+	private:
+		static constexpr char DEFAULT_SLN_PATH_WITHOUT_LAST_BACKSLASH[] = "C:\\proj\\sln";
+		static constexpr char DEFAULT_SLN_PATH[] = "C:\\proj\\sln\\";
+	public:
 		TEST_CLASS_INITIALIZE(Init)
 		{
 			// create test files
@@ -25,18 +29,8 @@ namespace TestRuntimeNotifications
 			FileSystem::CreateTestFile("C:\\proj\\lib\\ignoreFile.h", "ignoreFile.h contents");
 		}
 
-		TEST_METHOD_INITIALIZE(MethodInit)
-		{
-			// set default SolutionPath
-			auto& options = RuntimeOptions::Instance();
-			options.SolutionPath = "C:\\proj\\sln\\";
-		}
-
 		TEST_CLASS_CLEANUP(CleanUp)
 		{
-			auto& options = RuntimeOptions::Instance();
-			options.SolutionPath.clear();
-
 			FileSystem::DeleteTestFiles();
 		}
 
@@ -46,7 +40,9 @@ namespace TestRuntimeNotifications
 		{
 			static constexpr std::string_view LINE = "IGNORE FILE: C:\\proj\\lib\\notExist.cpp";
 
-			RuntimeNotifications notifications;
+			RuntimeOptions opts;
+			opts.SolutionPath = DEFAULT_SLN_PATH;
+			RuntimeNotifications notifications(opts);
 			notifications.Handle(LINE.data(), LINE.size());
 
 			Assert::IsFalse(notifications.IgnoreFile("C:\\proj\\lib\\notExist.cpp"));
@@ -56,7 +52,9 @@ namespace TestRuntimeNotifications
 		{
 			static constexpr std::string_view LINE = "IGNORE FILE: C:\\proj\\lib\\";
 
-			RuntimeNotifications notifications;
+			RuntimeOptions opts;
+			opts.SolutionPath = DEFAULT_SLN_PATH;
+			RuntimeNotifications notifications(opts);
 			notifications.Handle(LINE.data(), LINE.size());
 
 			Assert::IsFalse(notifications.IgnoreFile("C:\\proj\\lib\\ignoreFile.cpp"));
@@ -67,7 +65,9 @@ namespace TestRuntimeNotifications
 			// check also trim path
 			static constexpr std::string_view LINE = "IGNORE FILE:   C:\\proj\\lib\\ignoreFile.c  ";
 
-			RuntimeNotifications notifications;
+			RuntimeOptions opts;
+			opts.SolutionPath = DEFAULT_SLN_PATH;
+			RuntimeNotifications notifications(opts);
 			notifications.Handle(LINE.data(), LINE.size());
 
 			Assert::IsFalse(notifications.IgnoreFile("C:\\proj\\lib\\ignoreFile.cpp"));
@@ -80,7 +80,9 @@ namespace TestRuntimeNotifications
 			// check also trim path
 			static constexpr std::string_view LINE = "IGNORE FILE:..\\lib\\ignoreFile.c  ";
 
-			RuntimeNotifications notifications;
+			RuntimeOptions opts;
+			opts.SolutionPath = DEFAULT_SLN_PATH;
+			RuntimeNotifications notifications(opts);
 			notifications.Handle(LINE.data(), LINE.size());
 
 			Assert::IsFalse(notifications.IgnoreFile("C:\\proj\\lib\\ignoreFile.cpp"));
@@ -90,11 +92,11 @@ namespace TestRuntimeNotifications
 
 		TEST_METHOD(IgnoreFileRelativeSolutionPathWithoutLastBackslash)
 		{
-			RuntimeOptions::Instance().SolutionPath = "C:\\proj\\sln";
-
 			static constexpr std::string_view LINE = "IGNORE FILE:..\\lib\\ignoreFile.c  ";
 
-			RuntimeNotifications notifications;
+			RuntimeOptions opts;
+			opts.SolutionPath = DEFAULT_SLN_PATH_WITHOUT_LAST_BACKSLASH;
+			RuntimeNotifications notifications(opts);
 			notifications.Handle(LINE.data(), LINE.size());
 
 			Assert::IsFalse(notifications.IgnoreFile("C:\\proj\\lib\\ignoreFile.cpp"));
@@ -106,7 +108,9 @@ namespace TestRuntimeNotifications
 		{
 			static constexpr std::string_view LINE = "IGNORE FILE: \\dir\\file.c";
 
-			RuntimeNotifications notifications;
+			RuntimeOptions opts;
+			opts.SolutionPath = DEFAULT_SLN_PATH;
+			RuntimeNotifications notifications(opts);
 			notifications.Handle(LINE.data(), LINE.size());
 
 			Assert::IsTrue(notifications.IgnoreFile("C:\\proj\\sln\\dir\\file.c"));
@@ -114,11 +118,11 @@ namespace TestRuntimeNotifications
 
 		TEST_METHOD(IgnoreFileWithoutParentDirRelativeSolutionPathWithoutLastBackslash)
 		{
-			RuntimeOptions::Instance().SolutionPath = "C:\\proj\\sln";
-
 			static constexpr std::string_view LINE = "IGNORE FILE: \\dir\\file.c";
 
-			RuntimeNotifications notifications;
+			RuntimeOptions opts;
+			opts.SolutionPath = DEFAULT_SLN_PATH_WITHOUT_LAST_BACKSLASH;
+			RuntimeNotifications notifications(opts);
 			notifications.Handle(LINE.data(), LINE.size());
 
 			Assert::IsTrue(notifications.IgnoreFile("C:\\proj\\sln\\dir\\file.c"));
@@ -126,11 +130,11 @@ namespace TestRuntimeNotifications
 
 		TEST_METHOD(IgnoreFileWithoutParentDirStartsWithDirName)
 		{
-			RuntimeOptions::Instance().SolutionPath = "C:\\proj\\sln";
-
 			static constexpr std::string_view LINE = "IGNORE FILE: dir\\file.c";
 
-			RuntimeNotifications notifications;
+			RuntimeOptions opts;
+			opts.SolutionPath = DEFAULT_SLN_PATH_WITHOUT_LAST_BACKSLASH;
+			RuntimeNotifications notifications(opts);
 			notifications.Handle(LINE.data(), LINE.size());
 
 			Assert::IsTrue(notifications.IgnoreFile("C:\\proj\\sln\\dir\\file.c"));
@@ -138,11 +142,10 @@ namespace TestRuntimeNotifications
 
 		TEST_METHOD(IgnoreFileRelativeWithoutSolutionPath)
 		{
-			RuntimeOptions::Instance().SolutionPath.clear();
-
 			static constexpr std::string_view LINE = "IGNORE FILE:..\\lib\\ignoreFile.c  ";
 
-			RuntimeNotifications notifications;
+			RuntimeOptions opts;
+			RuntimeNotifications notifications(opts);
 			notifications.Handle(LINE.data(), LINE.size());
 
 			Assert::IsFalse(notifications.IgnoreFile("C:\\proj\\lib\\ignoreFile.c"));
@@ -152,7 +155,9 @@ namespace TestRuntimeNotifications
 		{
 			static constexpr std::string_view LINE = "IGNORE FILE:..\\..\\..\\lib\\ignoreFile.c  ";
 
-			RuntimeNotifications notifications;
+			RuntimeOptions opts;
+			opts.SolutionPath = DEFAULT_SLN_PATH;
+			RuntimeNotifications notifications(opts);
 			notifications.Handle(LINE.data(), LINE.size());
 
 			Assert::IsFalse(notifications.IgnoreFile("C:\\proj\\lib\\ignoreFile.c"));
@@ -164,7 +169,9 @@ namespace TestRuntimeNotifications
 		{
 			static constexpr std::string_view LINE = "IGNORE FOLDER: C:\\proj\\notExist\\";
 
-			RuntimeNotifications notifications;
+			RuntimeOptions opts;
+			opts.SolutionPath = DEFAULT_SLN_PATH;
+			RuntimeNotifications notifications(opts);
 			notifications.Handle(LINE.data(), LINE.size());
 
 			Assert::IsFalse(notifications.IgnoreFile("C:\\proj\\lib\\notExist\\"));
@@ -174,7 +181,9 @@ namespace TestRuntimeNotifications
 		{
 			static constexpr std::string_view LINE = "IGNORE FOLDER: C:\\proj\\lib\\ignoreFile.cpp";
 
-			RuntimeNotifications notifications;
+			RuntimeOptions opts;
+			opts.SolutionPath = DEFAULT_SLN_PATH;
+			RuntimeNotifications notifications(opts);
 			notifications.Handle(LINE.data(), LINE.size());
 
 			Assert::IsFalse(notifications.IgnoreFile("C:\\proj\\lib\\ignoreFile.cpp"));
@@ -185,7 +194,9 @@ namespace TestRuntimeNotifications
 			// check also trim path
 			static constexpr std::string_view LINE = "IGNORE FOLDER:   C:\\proj\\src\\ignoreFolder1  ";
 
-			RuntimeNotifications notifications;
+			RuntimeOptions opts;
+			opts.SolutionPath = DEFAULT_SLN_PATH;
+			RuntimeNotifications notifications(opts);
 			notifications.Handle(LINE.data(), LINE.size());
 
 			Assert::IsTrue(notifications.IgnoreFile("C:\\proj\\src\\ignoreFolder1\\srcFile.cpp"));
@@ -200,7 +211,9 @@ namespace TestRuntimeNotifications
 			// check also trim path
 			static constexpr std::string_view LINE = "IGNORE FOLDER:   ..\\src\\ignoreFolder1\\";
 
-			RuntimeNotifications notifications;
+			RuntimeOptions opts;
+			opts.SolutionPath = DEFAULT_SLN_PATH;
+			RuntimeNotifications notifications(opts);
 			notifications.Handle(LINE.data(), LINE.size());
 
 			Assert::IsTrue(notifications.IgnoreFile("C:\\proj\\src\\ignoreFolder1\\srcFile.cpp"));
@@ -212,11 +225,11 @@ namespace TestRuntimeNotifications
 
 		TEST_METHOD(IgnoreFolderRelativeSolutionPathWithoutLastBackslash)
 		{
-			RuntimeOptions::Instance().SolutionPath = "C:\\proj\\sln";
-
 			static constexpr std::string_view LINE = "IGNORE FOLDER:   ..\\src\\ignoreFolder1";
 
-			RuntimeNotifications notifications;
+			RuntimeOptions opts;
+			opts.SolutionPath = DEFAULT_SLN_PATH_WITHOUT_LAST_BACKSLASH;
+			RuntimeNotifications notifications(opts);
 			notifications.Handle(LINE.data(), LINE.size());
 
 			Assert::IsTrue(notifications.IgnoreFile("C:\\proj\\src\\ignoreFolder1\\srcFile.cpp"));
@@ -230,7 +243,9 @@ namespace TestRuntimeNotifications
 		{
 			static constexpr std::string_view LINE = "IGNORE FOLDER: \\dir\\";
 
-			RuntimeNotifications notifications;
+			RuntimeOptions opts;
+			opts.SolutionPath = DEFAULT_SLN_PATH;
+			RuntimeNotifications notifications(opts);
 			notifications.Handle(LINE.data(), LINE.size());
 
 			Assert::IsTrue(notifications.IgnoreFile("C:\\proj\\sln\\dir\\file.cpp"));
@@ -239,11 +254,11 @@ namespace TestRuntimeNotifications
 
 		TEST_METHOD(IgnoreFolderWithoutParentDirRelativeSolutionPathWithoutLastBackslash)
 		{
-			RuntimeOptions::Instance().SolutionPath = "C:\\proj\\sln";
-
 			static constexpr std::string_view LINE = "IGNORE FOLDER: \\dir";
 
-			RuntimeNotifications notifications;
+			RuntimeOptions opts;
+			opts.SolutionPath = DEFAULT_SLN_PATH_WITHOUT_LAST_BACKSLASH;
+			RuntimeNotifications notifications(opts);
 			notifications.Handle(LINE.data(), LINE.size());
 
 			Assert::IsTrue(notifications.IgnoreFile("C:\\proj\\sln\\dir\\file.cpp"));
@@ -252,11 +267,11 @@ namespace TestRuntimeNotifications
 
 		TEST_METHOD(IgnoreFolderWithoutParentDirStartsWithDirName)
 		{
-			RuntimeOptions::Instance().SolutionPath = "C:\\proj\\sln";
-
 			static constexpr std::string_view LINE = "IGNORE FOLDER: dir";
 
-			RuntimeNotifications notifications;
+			RuntimeOptions opts;
+			opts.SolutionPath = DEFAULT_SLN_PATH_WITHOUT_LAST_BACKSLASH;
+			RuntimeNotifications notifications(opts);
 			notifications.Handle(LINE.data(), LINE.size());
 
 			Assert::IsTrue(notifications.IgnoreFile("C:\\proj\\sln\\dir\\file.cpp"));
@@ -265,11 +280,10 @@ namespace TestRuntimeNotifications
 
 		TEST_METHOD(IgnoreFolderRelativeWithoutSolutionPath)
 		{
-			RuntimeOptions::Instance().SolutionPath.clear();
-
 			static constexpr std::string_view LINE = "IGNORE FOLDER:   ..\\src\\ignoreFolder1";
 
-			RuntimeNotifications notifications;
+			RuntimeOptions opts;
+			RuntimeNotifications notifications(opts);
 			notifications.Handle(LINE.data(), LINE.size());
 
 			Assert::IsFalse(notifications.IgnoreFile("C:\\proj\\src\\ignoreFolder1\\srcFile.cpp"));
@@ -280,7 +294,9 @@ namespace TestRuntimeNotifications
 		{
 			static constexpr std::string_view LINE = "IGNORE FOLDER:   ..\\..\\..\\src\\ignoreFolder1";
 
-			RuntimeNotifications notifications;
+			RuntimeOptions opts;
+			opts.SolutionPath = DEFAULT_SLN_PATH;
+			RuntimeNotifications notifications(opts);
 			notifications.Handle(LINE.data(), LINE.size());
 
 			Assert::IsFalse(notifications.IgnoreFile("C:\\proj\\src\\ignoreFolder1\\srcFile.cpp"));
@@ -291,26 +307,26 @@ namespace TestRuntimeNotifications
 
 		TEST_METHOD(EnableCodeAnalysis)
 		{
-			RuntimeOptions::Instance().UseStaticCodeAnalysis = false;
-
 			static constexpr std::string_view LINE = "ENABLE CODE ANALYSIS";
 
-			RuntimeNotifications notifications;
+			RuntimeOptions opts;
+			opts.UseStaticCodeAnalysis = false;
+			RuntimeNotifications notifications(opts);
 			notifications.Handle(LINE.data(), LINE.size());
 
-			Assert::IsTrue(RuntimeOptions::Instance().UseStaticCodeAnalysis);
+			Assert::IsTrue(opts.UseStaticCodeAnalysis);
 		}
 
 		TEST_METHOD(DisableCodeAnalysis)
 		{
-			RuntimeOptions::Instance().UseStaticCodeAnalysis = true;
-
 			static constexpr std::string_view LINE = "DISABLE CODE ANALYSIS";
 
-			RuntimeNotifications notifications;
+			RuntimeOptions opts;
+			opts.UseStaticCodeAnalysis = true;
+			RuntimeNotifications notifications(opts);
 			notifications.Handle(LINE.data(), LINE.size());
 
-			Assert::IsFalse(RuntimeOptions::Instance().UseStaticCodeAnalysis);
+			Assert::IsFalse(opts.UseStaticCodeAnalysis);
 		}
 	};
 }


### PR DESCRIPTION
Original reason from #119: Split singleton RuntimeOptions to write test without them.

@Rominitch I've extracted this section of changes from issue #119 along with a few improvements to make them easier to review.